### PR TITLE
refactor: rename plugin id to redmine_cloud_attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog — Redmine Cloud Attachment
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] — 2026-07-24
+
+### Changed
+
+- **Plugin rename**: directory / plugin id `redmine_cloud_attachment_pro` → `redmine_cloud_attachment`
+- Ruby module `RedmineCloudAttachmentPro` → `RedmineCloudAttachment`
+- Display name: "Redmine Cloud Attachment" (drop "Pro")
+- Config key preference: `Redmine::Configuration['cloud_attachment']` (falls back to legacy `cloud_attachment_pro`)
+- Canonical GitHub repo: https://github.com/redmineshop/redmine_cloud_attachment
+
+### Upgrade notes
+
+1. Stop Redmine.
+2. Rename the plugin folder:
+   ```bash
+   mv plugins/redmine_cloud_attachment_pro plugins/redmine_cloud_attachment
+   ```
+   Or remove the old folder and install the new package into `plugins/redmine_cloud_attachment`.
+3. Restart Redmine.
+4. Optional: rename `cloud_attachment_pro:` → `cloud_attachment:` in `config/configuration.yml`.
+
+## [1.1.1] — 2026-07-19
+
+### Added
+
+- First community release via RedmineShop. Based on [railsfactory-sivamanikandan/redmine_cloud_attachment_pro](https://github.com/railsfactory-sivamanikandan/redmine_cloud_attachment_pro) (MIT), extended for S3 presigned URL support.
+
+### Features
+
+- Multi-backend cloud storage: AWS S3, Google Cloud Storage, Azure Blob
+- Presigned URL downloads (offload bandwidth from Redmine)
+- Thumbnail generation for cloud-stored images
+- Compatible with Redmine 5.0.x and 6.x
+
+[1.2.0]: https://github.com/redmineshop/redmine_cloud_attachment/releases/tag/v1.2.0
+[1.1.1]: https://github.com/redmineshop/redmine_cloud_attachment/releases/tag/v1.1.1

--- a/README.md
+++ b/README.md
@@ -1,376 +1,74 @@
-# Redmine Cloud Attachment Pro
+# Redmine Cloud Attachment — S3, GCS & Azure Storage for Redmine
 
-A plugin for Redmine that enables storing attachments in multiple cloud backends (S3, Google Cloud Storage, Azure Blob Storage) with direct download optimization.
+[![Community · Free forever](https://img.shields.io/badge/Community-Free%20forever-brightgreen)](https://redmineshop.com/products/redmine-cloud-attachment)
+[![Redmine 5.x/6.x](https://img.shields.io/badge/Redmine-5.x%20%7C%206.x-blue)](https://redmineshop.com/docs/compatibility)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow)](LICENSE.txt)
 
-## Table of Contents
+**Download via RedmineShop:** [redmineshop.com/products/redmine-cloud-attachment](https://redmineshop.com/products/redmine-cloud-attachment)
 
-- [Key Features](#key-features)
-- [Performance Benefits](#performance-benefits)
-- [Configuration](#configuration)
-- [Installation](#installation)
-- [Monitoring and Logs](#monitoring-and-logs)
-- [API Enhancements](#api-enhancements)
-- [Testing](#testing)
-- [Troubleshooting](#troubleshooting)
-- [Migration from Local Storage](#migration-from-local-storage)
-- [Development](#development)
-- [Security Notes](#security-notes)
-- [Performance Monitoring](#performance-monitoring)
-- [License](#license)
+Store Redmine issue attachments in cloud object storage — AWS S3, Google Cloud Storage, or Azure Blob — instead of local disk. Supports presigned URLs for secure, time-limited direct download links that bypass your Redmine server.
 
-## Key Features
+## Features
 
-- **Multiple Cloud Backends**: Support for AWS S3, Google Cloud Storage, and Azure Blob Storage
-- **Direct Download Optimization**: Offloads file serving to cloud storage using presigned URLs
-- **Bandwidth Saving**: Reduces server bandwidth usage by redirecting users directly to cloud storage
-- **Performance Boost**: Eliminates temporary file creation for cloud attachments
-- **API Integration**: Enhanced API responses with direct cloud URLs
-- **Fallback Support**: Graceful fallback to local serving when cloud access fails
+- Route Redmine file uploads directly to AWS S3, GCS, or Azure Blob
+- Presigned URL downloads — files served directly from cloud, not through Redmine server
+- No local disk storage required (offload large attachments)
+- Configurable via `config/configuration.yml`
+- Compatible with Redmine's built-in attachment management UI
 
-## Performance Benefits
+## Requirements
 
-### Before Optimization:
-```
-User Request → Redmine → Download from Cloud → Create Temp File → Serve to User
-```
-
-### After Optimization:
-```
-User Request → Redmine → Generate Presigned URL → Redirect User to Cloud Storage
-```
-
-**Results:**
-- ⚡ **Faster downloads** - Direct access to cloud storage
-- 💾 **No temporary files** - Eliminates disk space consumption  
-- 🚀 **Reduced server load** - Offloads file serving to cloud providers
-- 📊 **Lower bandwidth costs** - Files served directly from cloud storage
-
-## Configuration
-
-### Basic Storage Configuration
-
-Add to your `config/configuration.yml`:
-
-```yaml
-production:
-  # Set storage backend
-  storage: s3  # or 'gcs' or 'azure'
-  
-  # S3 Configuration
-  s3:
-    access_key_id: "your_access_key"
-    secret_access_key: "your_secret_key"
-    bucket: "your_bucket_name"
-    region: "your_region"
-    path: "redmine/files"  # Optional: custom path prefix
-  
-  # Google Cloud Storage Configuration  
-  gcs:
-    project_id: "your_project_id"
-    bucket: "your_bucket_name"
-    gcs_credentials: "/path/to/service_account.json"
-    path: "redmine/files"
-  
-  # Azure Blob Storage Configuration
-  azure:
-    account_name: "your_account_name" 
-    access_key: "your_access_key"
-    container: "your_container_name"
-    path: "redmine/files"
-```
-
-### Advanced Configuration
-
-```yaml
-production:
-  # Cloud Attachment Pro specific settings
-  cloud_attachment_pro:
-    # Presigned URL expiration time (in minutes, default: 15)
-    presigned_url_expires_in: 60
-```
+- Redmine 5.0.x or 6.x
+- Ruby 3.0+
+- AWS S3 bucket (+ IAM credentials), GCS bucket, or Azure Storage account
 
 ## Installation
 
-1. Copy this plugin to your Redmine plugins directory:
-   ```bash
-   cd /path/to/redmine
-   git clone https://github.com/your-repo/redmine_cloud_attachment_pro.git plugins/redmine_cloud_attachment_pro
-   ```
-
-2. Install dependencies:
-   ```bash
-   cd plugins/redmine_cloud_attachment_pro
-   bundle install
-   ```
-
-3. Configure your cloud storage settings in `config/configuration.yml`
-
-4. Restart Redmine:
-   ```bash
-   sudo systemctl restart redmine
-   # or if using Passenger/Puma
-   touch tmp/restart.txt
-   ```
-
-## Monitoring and Logs
-
-Monitor the plugin performance through log entries:
+Download the SHA256-verified package from [RedmineShop](https://redmineshop.com/products/redmine-cloud-attachment), then:
 
 ```bash
-# Monitor direct cloud redirects
-tail -f log/production.log | grep "CloudAttachmentPro.*Redirecting to presigned URL"
-
-# Monitor fallbacks to local serving  
-tail -f log/production.log | grep "CloudAttachmentPro.*Using original download method"
-
-# Monitor potential issues
-tail -f log/production.log | grep "CloudAttachmentPro.*ERROR"
+# From your Redmine root
+tar -xzf redmine_cloud_attachment-1.2.0.tar.gz -C plugins/
+bundle exec rake redmine:plugins:migrate RAILS_ENV=production
+# Restart your Redmine server
 ```
 
-## API Enhancements
+See the [install guide](https://redmineshop.com/docs/cloud-attachment-install) for full instructions.
 
-The plugin enhances API responses with direct cloud URLs:
+### Upgrading from `redmine_cloud_attachment`
 
-```json
-{
-  "attachment": {
-    "id": 123,
-    "filename": "document.pdf",
-    "content_url": "/attachments/download/123/document.pdf",
-    "direct_content_url": "https://bucket.s3.amazonaws.com/path/to/file?X-Amz-..."
-  }
-}
+```bash
+mv plugins/redmine_cloud_attachment plugins/redmine_cloud_attachment
+# Restart Redmine
 ```
 
-Use `direct_content_url` for optimal performance in API clients.
+Optional: rename `cloud_attachment_pro:` → `cloud_attachment:` in `configuration.yml` (legacy key still works).
 
-## Troubleshooting
+## Configuration
 
-### Common Issues
+Edit `config/configuration.yml` (see `config/configuration.yml.sample`):
 
-1. **Files not redirecting to cloud storage**
-   - Check cloud configuration in `configuration.yml`
-   - Verify storage backend is set correctly
-   - Check logs for error messages
-
-2. **Presigned URL generation failures**
-   - Verify cloud credentials are correct
-   - Check cloud provider IAM permissions
-   - Ensure bucket/container exists
-
-3. **Images not displaying directly**
-   - Verify CORS settings on your cloud storage
-   - Check browser network tab for failed requests
-
-### Debugging
-
-Enable debug logging by adding to your configuration:
+### AWS S3 example
 
 ```yaml
 production:
-  log_level: debug
+  storage: :s3
+  s3:
+    enabled: true
+    access_key_id: <%= ENV["AWS_ACCESS_KEY"] %>
+    secret_access_key: <%= ENV["AWS_SECRET_KEY"] %>
+    bucket: <%= ENV["REDMINE_FILES_ATTACHEMENT_S3_BUCKET"] %>
+    region: <%= ENV["AWS_REGION"] %>
+    path: <%= ENV["AWS_PATH"] %>
+  # Optional plugin settings (legacy key cloud_attachment_pro also accepted):
+  cloud_attachment:
+    presigned_url_expires_in: 15
 ```
 
-## Testing
+## Troubleshooting
 
-This plugin includes a comprehensive test suite to ensure reliability and proper functionality.
-
-### Test Suite Structure
-
-```
-test/
-├── unit/
-│   ├── basic_functionality_test.rb           # Core functionality tests
-│   ├── cloud_attachment_optimization_test.rb # Optimization feature tests
-│   └── cloud_attachment_thumbnail_test.rb    # Thumbnail generation tests
-├── integration/
-│   └── cloud_attachment_integration_test.rb  # End-to-end integration tests
-├── setup_test_db.sh                          # Database setup script
-└── run_tests.sh                              # Test execution script
-```
-
-### Running Tests
-
-#### Prerequisites
-
-1. **Install test dependencies**:
-   ```bash
-   cd plugins/redmine_cloud_attachment_pro
-   bundle install --with test
-   ```
-
-2. **Setup test database** (if not already configured):
-   ```bash
-   chmod +x test/setup_test_db.sh
-   ./test/setup_test_db.sh
-   ```
-
-#### Running All Tests
-
-```bash
-# Using the provided script
-chmod +x test/run_tests.sh
-./test/run_tests.sh
-
-# Or manually from Redmine root
-cd /path/to/redmine
-bundle exec rails test plugins/redmine_cloud_attachment_pro/test/**/*_test.rb
-```
-
-#### Running Specific Test Suites
-
-```bash
-# Basic functionality tests
-bundle exec rails test plugins/redmine_cloud_attachment_pro/test/unit/basic_functionality_test.rb
-
-# Optimization tests
-bundle exec rails test plugins/redmine_cloud_attachment_pro/test/unit/cloud_attachment_optimization_test.rb
-
-# Thumbnail tests
-bundle exec rails test plugins/redmine_cloud_attachment_pro/test/unit/cloud_attachment_thumbnail_test.rb
-
-# Integration tests
-bundle exec rails test plugins/redmine_cloud_attachment_pro/test/integration/cloud_attachment_integration_test.rb
-```
-
-#### Running Individual Tests
-
-```bash
-# Run a specific test method
-bundle exec rails test plugins/redmine_cloud_attachment_pro/test/unit/basic_functionality_test.rb -n test_plugin_loaded_correctly
-
-# Run with verbose output
-bundle exec rails test plugins/redmine_cloud_attachment_pro/test/unit/basic_functionality_test.rb -v
-```
-
-### Test Environment Setup
-
-The tests use the same database configuration as your Redmine test environment. Make sure your `config/database.yml` includes a test section:
-
-```yaml
-test:
-  adapter: mysql2
-  database: redmine_test
-  host: localhost
-  username: redmine
-  password: "your_password"
-  encoding: utf8mb4
-```
-
-### Test Coverage
-
-The test suite covers:
-
-- ✅ **Plugin Loading**: Ensures plugin loads correctly with all patches
-- ✅ **Configuration**: Tests configuration reading and validation
-- ✅ **Cloud Detection**: Tests cloud vs local file detection
-- ✅ **Direct URLs**: Tests presigned URL generation
-- ✅ **Thumbnail Generation**: Tests thumbnail creation for cloud files
-- ✅ **Performance Optimization**: Tests bandwidth-saving features
-- ✅ **API Integration**: Tests enhanced API responses
-- ✅ **Error Handling**: Tests graceful fallbacks
-
-### Continuous Integration
-
-For CI/CD pipelines, use:
-
-```bash
-# Setup test environment
-bundle install --with test
-bundle exec rails db:test:prepare RAILS_ENV=test
-
-# Run all plugin tests
-bundle exec rails test plugins/redmine_cloud_attachment_pro/test/**/*_test.rb RAILS_ENV=test
-```
-
-### Development Testing
-
-During development, you can run tests in watch mode or with specific filters:
-
-```bash
-# Test specific functionality
-bundle exec rails test plugins/redmine_cloud_attachment_pro/test/unit/basic_functionality_test.rb -n /cloud/
-
-# Run tests with debugging
-bundle exec rails test plugins/redmine_cloud_attachment_pro/test/unit/basic_functionality_test.rb --verbose
-```
-
-## Migration from Local Storage
-
-To migrate existing local attachments to cloud storage:
-
-1. Configure cloud storage settings
-2. Set `storage: your_cloud_backend` in configuration
-3. New uploads will go to cloud storage
-4. Existing local files remain accessible
-5. Optionally migrate old files using custom scripts
-
-## Security Notes
-
-- Presigned URLs have configurable expiration times
-- All Redmine permission checks are preserved
-- Cloud access requires valid Redmine session
-- Direct URLs are temporary and expire automatically
-
-## Supported Cloud Providers
-
-- **AWS S3**: Full support with presigned URLs
-- **Google Cloud Storage**: Full support with signed URLs  
-- **Azure Blob Storage**: Full support with SAS tokens
-
-## Performance Monitoring
-
-Key metrics to monitor:
-
-- Percentage of requests using direct cloud URLs vs local serving
-- Reduction in server bandwidth usage
-- Improvement in download speeds
-- Reduction in temporary file creation
-
-## Development
-
-### Plugin Architecture
-
-The plugin uses a patch-based architecture to extend Redmine's core functionality:
-
-```
-lib/redmine_cloud_attachment_pro/
-├── attachment_patch.rb              # Core attachment model extensions
-├── patches/
-│   ├── attachments_controller_patch.rb # Controller optimizations
-│   └── attachments_helper_patch.rb     # Helper method extensions
-└── version.rb                       # Plugin version
-```
-
-### Key Components
-
-- **AttachmentPatch**: Adds cloud detection and direct URL generation
-- **AttachmentsControllerPatch**: Implements presigned URL redirects
-- **AttachmentsHelperPatch**: Enhances API responses with cloud URLs
-
-### Development Workflow
-
-1. **Make changes** to plugin files
-2. **Run tests** to ensure functionality:
-   ```bash
-   ./test/run_tests.sh
-   ```
-3. **Restart Redmine** to apply changes:
-   ```bash
-   sudo systemctl restart redmine
-   # or
-   touch tmp/restart.txt
-   ```
-4. **Test in browser** with actual cloud files
-5. **Monitor logs** for proper behavior:
-   ```bash
-   tail -f log/production.log | grep CloudAttachmentPro
-   ```
+See [docs/cloud-attachment-troubleshooting](https://redmineshop.com/docs/cloud-attachment-troubleshooting) or open an issue at [GitHub Issues](https://github.com/redmineshop/redmine_cloud_attachment/issues).
 
 ## License
 
-This plugin is released under the same license as Redmine.
-
-## Support
-
-For issues and feature requests, please use the GitHub issue tracker.
+MIT — see [LICENSE.txt](LICENSE.txt). Based on [railsfactory-sivamanikandan/redmine_cloud_attachment_pro](https://github.com/railsfactory-sivamanikandan/redmine_cloud_attachment_pro).

--- a/init.rb
+++ b/init.rb
@@ -1,82 +1,81 @@
+# frozen_string_literal: true
+
 require 'redmine'
 require_dependency 'redmine/plugin'
-# Do not require patches directly here if using to_prepare for loading
-# require_relative 'lib/redmine_cloud_attachment_pro/attachment_patch'
+require_relative 'lib/redmine_cloud_attachment/version'
 
-# Rails.logger.info "[CloudAttachmentPro INIT] Registering plugin: redmine_cloud_attachment_pro. File: #{__FILE__}"
+Redmine::Plugin.register :redmine_cloud_attachment do
+  name 'Redmine Cloud Attachment'
+  author 'RedmineShop (based on railsfactory/redmine_cloud_attachment)'
+  description 'Store Redmine attachments in AWS S3, Google Cloud Storage, or Azure Blob — with presigned URL support for secure direct downloads.'
+  version RedmineCloudAttachment::VERSION
+  url 'https://redmineshop.com/products/redmine-cloud-attachment'
+  author_url 'https://redmineshop.com'
 
-Redmine::Plugin.register :redmine_cloud_attachment_pro do
-  name 'Redmine Cloud Attachment Pro'
-  author 'Railsfactory & TuannNDE (modified for S3 Presigned URL)'
-  description 'A plugin for Redmine that enables storing attachments in multiple cloud backends with S3 presigned URL support.'
-  version '1.1.1' # Incremented version
-  url 'https://github.com/railsfactory-sivamanikandan/redmine_cloud_attachment_pro'
-  author_url 'https://github.com/tuannde'
-
-  # Rails.logger.info "[CloudAttachmentPro INIT] Inside plugin registration block."
+  # Rails.logger.info "[CloudAttachment INIT] Inside plugin registration block."
 
   # Plugin settings definition (if any)
   # settings default: { 'setting_key' => 'default_value' }, partial: 'settings/rcap_settings'
 
-  # Rails.logger.info "[CloudAttachmentPro INIT] Attempting to load and apply patches directly."
+  # Rails.logger.info "[CloudAttachment INIT] Attempting to load and apply patches directly."
 
   # Ensure Attachment class is loaded before patching
   begin
     require_dependency 'attachment' # Core Redmine class
-    patch_module_fqn = 'RedmineCloudAttachmentPro::AttachmentPatch'
-    patch_file_path = File.join(File.dirname(__FILE__), 'lib', 'redmine_cloud_attachment_pro', 'attachment_patch.rb')
-    # Rails.logger.info "[CloudAttachmentPro INIT] Requiring AttachmentPatch from: #{patch_file_path}"
+    patch_module_fqn = 'RedmineCloudAttachment::AttachmentPatch'
+    patch_file_path = File.join(File.dirname(__FILE__), 'lib', 'redmine_cloud_attachment', 'attachment_patch.rb')
+    # Rails.logger.info "[CloudAttachment INIT] Requiring AttachmentPatch from: #{patch_file_path}"
     require_dependency patch_file_path
-    # Rails.logger.info "[CloudAttachmentPro INIT] Successfully required AttachmentPatch."
+    # Rails.logger.info "[CloudAttachment INIT] Successfully required AttachmentPatch."
 
     patch_module = patch_module_fqn.constantize
     target_class = Attachment
 
     unless target_class.included_modules.include?(patch_module)
       target_class.send(:include, patch_module)
-      # Rails.logger.info "[CloudAttachmentPro INIT] Successfully patched Attachment model with #{patch_module_fqn}."
+      # Rails.logger.info "[CloudAttachment INIT] Successfully patched Attachment model with #{patch_module_fqn}."
     # else
-      # Rails.logger.info "[CloudAttachmentPro INIT] Attachment model already includes #{patch_module_fqn}."
+      # Rails.logger.info "[CloudAttachment INIT] Attachment model already includes #{patch_module_fqn}."
     end
   rescue LoadError => e
-    Rails.logger.error "[CloudAttachmentPro] Error loading/applying AttachmentPatch. Message: #{e.message}"
+    Rails.logger.error "[CloudAttachment] Error loading/applying AttachmentPatch. Message: #{e.message}"
   rescue NameError => e
-    Rails.logger.error "[CloudAttachmentPro] Error finding Attachment or AttachmentPatch module. Message: #{e.message}"
+    Rails.logger.error "[CloudAttachment] Error finding Attachment or AttachmentPatch module. Message: #{e.message}"
   rescue StandardError => e
-    Rails.logger.error "[CloudAttachmentPro] General error applying AttachmentPatch. Message: #{e.message}"
+    Rails.logger.error "[CloudAttachment] General error applying AttachmentPatch. Message: #{e.message}"
   end
 
   # Ensure AttachmentsController is loaded before patching
   begin
     require_dependency 'attachments_controller' # Core Redmine class
-    controller_patch_fqn = 'RedmineCloudAttachmentPro::Patches::AttachmentsControllerPatch'
-    controller_patch_path = File.join(File.dirname(__FILE__), 'lib', 'redmine_cloud_attachment_pro', 'patches', 'attachments_controller_patch.rb')
-    # Rails.logger.info "[CloudAttachmentPro INIT] Requiring AttachmentsControllerPatch from: #{controller_patch_path}"
+    controller_patch_fqn = 'RedmineCloudAttachment::Patches::AttachmentsControllerPatch'
+    controller_patch_path = File.join(File.dirname(__FILE__), 'lib', 'redmine_cloud_attachment', 'patches', 'attachments_controller_patch.rb')
+    # Rails.logger.info "[CloudAttachment INIT] Requiring AttachmentsControllerPatch from: #{controller_patch_path}"
     require_dependency controller_patch_path
-    # Rails.logger.info "[CloudAttachmentPro INIT] Successfully required AttachmentsControllerPatch."
+    # Rails.logger.info "[CloudAttachment INIT] Successfully required AttachmentsControllerPatch."
 
     patch_module = controller_patch_fqn.constantize
     target_controller = AttachmentsController
 
     unless target_controller.included_modules.include?(patch_module)
       target_controller.send(:include, patch_module) # Using include, ensure patch uses `included do` or `prepended do` as appropriate
-      # Rails.logger.info "[CloudAttachmentPro INIT] Successfully patched AttachmentsController with #{controller_patch_fqn}."
+      # Rails.logger.info "[CloudAttachment INIT] Successfully patched AttachmentsController with #{controller_patch_fqn}."
     # else
-      # Rails.logger.info "[CloudAttachmentPro INIT] AttachmentsController already includes #{controller_patch_fqn}."
+      # Rails.logger.info "[CloudAttachment INIT] AttachmentsController already includes #{controller_patch_fqn}."
     end
   rescue LoadError => e
-    Rails.logger.error "[CloudAttachmentPro] Error loading/applying AttachmentsControllerPatch. Message: #{e.message}"
+    Rails.logger.error "[CloudAttachment] Error loading/applying AttachmentsControllerPatch. Message: #{e.message}"
   rescue NameError => e
-    Rails.logger.error "[CloudAttachmentPro] Error finding AttachmentsController or its patch module. Message: #{e.message}"
+    Rails.logger.error "[CloudAttachment] Error finding AttachmentsController or its patch module. Message: #{e.message}"
   rescue StandardError => e
-    Rails.logger.error "[CloudAttachmentPro] General error applying AttachmentsControllerPatch. Message: #{e.message}"
+    Rails.logger.error "[CloudAttachment] General error applying AttachmentsControllerPatch. Message: #{e.message}"
   end
 
   # Ensure AttachmentsHelper is loaded before patching
   begin
     require_dependency 'attachments_helper' # Core Redmine helper
-    helper_patch_fqn = 'RedmineCloudAttachmentPro::Patches::AttachmentsHelperPatch'
-    helper_patch_path = File.join(File.dirname(__FILE__), 'lib', 'redmine_cloud_attachment_pro', 'patches', 'attachments_helper_patch.rb')
+    helper_patch_fqn = 'RedmineCloudAttachment::Patches::AttachmentsHelperPatch'
+    helper_patch_path = File.join(File.dirname(__FILE__), 'lib', 'redmine_cloud_attachment', 'patches', 'attachments_helper_patch.rb')
     require_dependency helper_patch_path
 
     patch_module = helper_patch_fqn.constantize
@@ -84,20 +83,20 @@ Redmine::Plugin.register :redmine_cloud_attachment_pro do
 
     unless target_helper.included_modules.include?(patch_module)
       target_helper.send(:include, patch_module)
-      Rails.logger.debug "[CloudAttachmentPro] Successfully patched AttachmentsHelper with #{helper_patch_fqn}."
+      Rails.logger.debug "[CloudAttachment] Successfully patched AttachmentsHelper with #{helper_patch_fqn}."
     end
 
     # Also patch ApplicationHelper for thumbnail_path method
     ApplicationHelper.send(:include, patch_module) unless ApplicationHelper.included_modules.include?(patch_module)
   rescue LoadError => e
-    Rails.logger.error "[CloudAttachmentPro] Error loading/applying AttachmentsHelperPatch. Message: #{e.message}"
+    Rails.logger.error "[CloudAttachment] Error loading/applying AttachmentsHelperPatch. Message: #{e.message}"
   rescue NameError => e
-    Rails.logger.error "[CloudAttachmentPro] Error finding AttachmentsHelper or its patch module. Message: #{e.message}"
+    Rails.logger.error "[CloudAttachment] Error finding AttachmentsHelper or its patch module. Message: #{e.message}"
   rescue StandardError => e
-    Rails.logger.error "[CloudAttachmentPro] General error applying AttachmentsHelperPatch. Message: #{e.message}"
+    Rails.logger.error "[CloudAttachment] General error applying AttachmentsHelperPatch. Message: #{e.message}"
   end
 
   # Note: optimization_test.rb moved to test/ directory
 
-  # Rails.logger.info "[CloudAttachmentPro INIT] Exiting plugin registration block after attempting direct patch loading."
+  # Rails.logger.info "[CloudAttachment INIT] Exiting plugin registration block after attempting direct patch loading."
 end

--- a/lib/redmine_cloud_attachment/attachment_patch.rb
+++ b/lib/redmine_cloud_attachment/attachment_patch.rb
@@ -3,7 +3,7 @@ require 'google/cloud/storage'
 require 'azure/storage/blob'
 require_dependency 'attachment'
 
-module RedmineCloudAttachmentPro
+module RedmineCloudAttachment
   module AttachmentPatch
     def self.included(base)
       base.class_eval do
@@ -48,7 +48,7 @@ module RedmineCloudAttachmentPro
           return local_diskfile unless cloud_diskfile?
 
           # Log usage for monitoring - this should be rarely called if direct downloads are working
-          Rails.logger.info("[CloudAttachmentPro] diskfile() called for cloud attachment #{self.id} - consider using direct_download_url() for better performance")
+          Rails.logger.info("[CloudAttachment] diskfile() called for cloud attachment #{self.id} - consider using direct_download_url() for better performance")
 
           # Use instance variable to cache the temp file path per request/instance
           return @cached_temp_diskfile if @cached_temp_diskfile && File.exist?(@cached_temp_diskfile)
@@ -63,7 +63,7 @@ module RedmineCloudAttachmentPro
             @temp_file_obj.rewind
             @cached_temp_diskfile = @temp_file_obj.path
           rescue => e
-            Rails.logger.error("[CloudAttachmentPro] Fallback to local for attachment #{self.id} due to cloud download error: #{e.message}")
+            Rails.logger.error("[CloudAttachment] Fallback to local for attachment #{self.id} due to cloud download error: #{e.message}")
             cleanup_temp_file
             return local_diskfile
           end
@@ -77,7 +77,7 @@ module RedmineCloudAttachmentPro
           begin
             delete_from_backend(cloud_key)
           rescue => e
-            Rails.logger.error("[CloudAttachmentPro] Failed to delete #{cloud_key} from cloud for attachment #{self.id}: #{e.message}")
+            Rails.logger.error("[CloudAttachment] Failed to delete #{cloud_key} from cloud for attachment #{self.id}: #{e.message}")
           end
         end
 
@@ -105,7 +105,7 @@ module RedmineCloudAttachmentPro
           if cloud_diskfile?
             # For cloud files, we need to download and generate thumbnail locally
             # But we'll cache it to avoid repeated downloads
-            Rails.logger.debug("[CloudAttachmentPro] Generating thumbnail for cloud attachment #{self.id}")
+            Rails.logger.debug("[CloudAttachment] Generating thumbnail for cloud attachment #{self.id}")
             
             if thumbnailable? && readable?
               size = options[:size].to_i
@@ -138,7 +138,7 @@ module RedmineCloudAttachmentPro
                 
                 if logger
                   logger.error(
-                    "[CloudAttachmentPro] An error occurred while generating thumbnail for cloud attachment #{self.id}: #{e.message}"
+                    "[CloudAttachment] An error occurred while generating thumbnail for cloud attachment #{self.id}: #{e.message}"
                   )
                 end
                 return nil
@@ -152,9 +152,13 @@ module RedmineCloudAttachmentPro
 
         # Helper method to get expiry time from configuration
         def cloud_expiry_time
-          (Redmine::Configuration['cloud_attachment_pro'] && 
-           Redmine::Configuration['cloud_attachment_pro']['presigned_url_expires_in']) ? 
-           Redmine::Configuration['cloud_attachment_pro']['presigned_url_expires_in'].to_i.minutes : 15.minutes
+          plugin_cfg = Redmine::Configuration['cloud_attachment'] ||
+                       Redmine::Configuration['cloud_attachment_pro']
+          if plugin_cfg && plugin_cfg['presigned_url_expires_in']
+            plugin_cfg['presigned_url_expires_in'].to_i.minutes
+          else
+            15.minutes
+          end
         end
 
         # Check if attachment is stored in cloud
@@ -311,10 +315,10 @@ module RedmineCloudAttachmentPro
           begin
             signer = Aws::S3::Presigner.new(client: s3_client)
             url = signer.presigned_url(:get_object, bucket: s3_bucket, key: cloud_key, expires_in: expires_in.to_i)
-            Rails.logger.debug("[CloudAttachmentPro] Generated S3 presigned URL for attachment #{self.id}")
+            Rails.logger.debug("[CloudAttachment] Generated S3 presigned URL for attachment #{self.id}")
             url
           rescue => e
-            Rails.logger.error("[CloudAttachmentPro] Failed to generate S3 presigned URL for #{cloud_key} (attachment #{self.id}): #{e.message}")
+            Rails.logger.error("[CloudAttachment] Failed to generate S3 presigned URL for #{cloud_key} (attachment #{self.id}): #{e.message}")
             nil
           end
         end
@@ -329,10 +333,10 @@ module RedmineCloudAttachmentPro
             return nil unless file
             
             url = file.signed_url(method: "GET", expires: expires_in.to_i)
-            Rails.logger.debug("[CloudAttachmentPro] Generated GCS presigned URL for attachment #{self.id}")
+            Rails.logger.debug("[CloudAttachment] Generated GCS presigned URL for attachment #{self.id}")
             url
           rescue => e
-            Rails.logger.error("[CloudAttachmentPro] Failed to generate GCS presigned URL for #{cloud_key} (attachment #{self.id}): #{e.message}")
+            Rails.logger.error("[CloudAttachment] Failed to generate GCS presigned URL for #{cloud_key} (attachment #{self.id}): #{e.message}")
             nil
           end
         end
@@ -356,10 +360,10 @@ module RedmineCloudAttachmentPro
             )
             
             url = azure_blob_client.generate_uri("#{azure_container}/#{cloud_key}") + "?#{sas_token}"
-            Rails.logger.debug("[CloudAttachmentPro] Generated Azure presigned URL for attachment #{self.id}")
+            Rails.logger.debug("[CloudAttachment] Generated Azure presigned URL for attachment #{self.id}")
             url
           rescue => e
-            Rails.logger.error("[CloudAttachmentPro] Failed to generate Azure presigned URL for #{cloud_key} (attachment #{self.id}): #{e.message}")
+            Rails.logger.error("[CloudAttachment] Failed to generate Azure presigned URL for #{cloud_key} (attachment #{self.id}): #{e.message}")
             nil
           end
         end
@@ -377,7 +381,7 @@ module RedmineCloudAttachmentPro
         # Clean up temp files after thumbnail generation
         def cleanup_after_thumbnail
           cleanup_temp_file
-          Rails.logger.debug("[CloudAttachmentPro] Cleaned up temp files after thumbnail generation for attachment #{self.id}")
+          Rails.logger.debug("[CloudAttachment] Cleaned up temp files after thumbnail generation for attachment #{self.id}")
         end
       end
     end
@@ -385,4 +389,4 @@ module RedmineCloudAttachmentPro
 end
 
 # Ensure the patch is applied only once
-Attachment.include RedmineCloudAttachmentPro::AttachmentPatch unless Attachment.included_modules.include?(RedmineCloudAttachmentPro::AttachmentPatch)
+Attachment.include RedmineCloudAttachment::AttachmentPatch unless Attachment.included_modules.include?(RedmineCloudAttachment::AttachmentPatch)

--- a/lib/redmine_cloud_attachment/patches/attachments_controller_patch.rb
+++ b/lib/redmine_cloud_attachment/patches/attachments_controller_patch.rb
@@ -1,5 +1,5 @@
-# Rails.logger.info "[CloudAttachmentPro LOAD] Attempting to load AttachmentsControllerPatch file: #{__FILE__}"
-module RedmineCloudAttachmentPro
+# Rails.logger.info "[CloudAttachment LOAD] Attempting to load AttachmentsControllerPatch file: #{__FILE__}"
+module RedmineCloudAttachment
   module Patches
     module AttachmentsControllerPatch
       extend ActiveSupport::Concern
@@ -22,7 +22,7 @@ module RedmineCloudAttachmentPro
 
             if presigned_url_value
               begin
-                Rails.logger.info "[CloudAttachmentPro] Redirecting to presigned URL for attachment ##{@attachment.id} (#{@attachment.filename}) - offloading to cloud storage"
+                Rails.logger.info "[CloudAttachment] Redirecting to presigned URL for attachment ##{@attachment.id} (#{@attachment.filename}) - offloading to cloud storage"
                 
                 # Update download counter for project/version attachments
                 if @attachment.container.is_a?(Version) || @attachment.container.is_a?(Project)
@@ -32,17 +32,17 @@ module RedmineCloudAttachmentPro
                 redirect_to presigned_url_value, allow_other_host: true
                 return # Crucial to prevent original_download_for_cloud_pro from executing
               rescue => e
-                Rails.logger.error "[CloudAttachmentPro] Error during presigned URL redirect for attachment ##{@attachment&.id}: #{e.message}. Falling back to normal download."
+                Rails.logger.error "[CloudAttachment] Error during presigned URL redirect for attachment ##{@attachment&.id}: #{e.message}. Falling back to normal download."
                 # Fall through to original_download_for_cloud_pro
               end
             else
-              Rails.logger.warn "[CloudAttachmentPro] Failed to generate presigned URL for attachment ##{@attachment.id}, falling back to normal download"
+              Rails.logger.warn "[CloudAttachment] Failed to generate presigned URL for attachment ##{@attachment.id}, falling back to normal download"
             end
           end
 
           # If no presigned URL, or an error occurred, or attachment doesn't support it,
           # or if the @attachment conditions were not met, call original download method.
-          Rails.logger.debug "[CloudAttachmentPro] Using original download method for attachment ##{@attachment&.id}"
+          Rails.logger.debug "[CloudAttachment] Using original download method for attachment ##{@attachment&.id}"
           original_download_for_cloud_pro
         end
 
@@ -51,7 +51,7 @@ module RedmineCloudAttachmentPro
           # For cloud files that need content reading (text files, diffs), we still need to download
           # But we can optimize by only doing this when necessary
           if @attachment&.respond_to?(:cloud_diskfile?) && @attachment.cloud_diskfile?
-            Rails.logger.debug "[CloudAttachmentPro] Processing show request for cloud attachment ##{@attachment.id} (#{@attachment.filename})"
+            Rails.logger.debug "[CloudAttachment] Processing show request for cloud attachment ##{@attachment.id} (#{@attachment.filename})"
             
             respond_to do |format|
               format.html do
@@ -66,7 +66,7 @@ module RedmineCloudAttachmentPro
                 
                 # For diff and text files, we need to download content
                 if @attachment.is_diff?
-                  Rails.logger.info "[CloudAttachmentPro] Downloading diff content from cloud for attachment ##{@attachment.id}"
+                  Rails.logger.info "[CloudAttachment] Downloading diff content from cloud for attachment ##{@attachment.id}"
                   @diff = File.read(@attachment.diskfile, :mode => "rb")
                   @diff_type = params[:type] || User.current.pref[:diff_type] || 'inline'
                   @diff_type = 'inline' unless %w(inline sbs).include?(@diff_type)
@@ -77,14 +77,14 @@ module RedmineCloudAttachmentPro
                   end
                   render :action => 'diff'
                 elsif @attachment.is_text? && @attachment.filesize <= Setting.file_max_size_displayed.to_i.kilobyte
-                  Rails.logger.info "[CloudAttachmentPro] Downloading text content from cloud for attachment ##{@attachment.id}"
+                  Rails.logger.info "[CloudAttachment] Downloading text content from cloud for attachment ##{@attachment.id}"
                   @content = File.read(@attachment.diskfile, :mode => "rb")
                   render :action => 'file'
                 elsif @attachment.is_image?
                   # For images, we can directly show the cloud URL if available
                   expires_in = @attachment.cloud_expiry_time
                   @direct_url = @attachment.direct_download_url(expires_in)
-                  Rails.logger.debug "[CloudAttachmentPro] Using direct cloud URL for image display: #{@direct_url.present?}"
+                  Rails.logger.debug "[CloudAttachment] Using direct cloud URL for image display: #{@direct_url.present?}"
                   render :action => 'image'
                 else
                   render :action => 'other'
@@ -129,7 +129,7 @@ module RedmineCloudAttachmentPro
             if @attachment.readable?
               true
             else
-              Rails.logger.error "[CloudAttachmentPro] Cloud attachment #{@attachment.id} is not accessible"
+              Rails.logger.error "[CloudAttachment] Cloud attachment #{@attachment.id} is not accessible"
               render_404
             end
           else

--- a/lib/redmine_cloud_attachment/patches/attachments_helper_patch.rb
+++ b/lib/redmine_cloud_attachment/patches/attachments_helper_patch.rb
@@ -1,4 +1,4 @@
-module RedmineCloudAttachmentPro
+module RedmineCloudAttachment
   module Patches
     module AttachmentsHelperPatch
       extend ActiveSupport::Concern
@@ -16,7 +16,7 @@ module RedmineCloudAttachmentPro
             direct_url = attachment.direct_download_url(expires_in)
             if direct_url
               api.direct_content_url direct_url
-              Rails.logger.debug "[CloudAttachmentPro] Added direct cloud URL to API response for attachment #{attachment.id}"
+              Rails.logger.debug "[CloudAttachment] Added direct cloud URL to API response for attachment #{attachment.id}"
             end
           end
         end

--- a/lib/redmine_cloud_attachment/version.rb
+++ b/lib/redmine_cloud_attachment/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module RedmineCloudAttachment
+  VERSION = '1.2.0'
+end

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# Script to run tests for redmine_cloud_attachment_pro plugin
+# Script to run tests for redmine_cloud_attachment plugin
 # Based on official Redmine Plugin Tutorial documentation
 
-echo "🧪 Running tests for redmine_cloud_attachment_pro plugin..."
+echo "🧪 Running tests for redmine_cloud_attachment plugin..."
 
 # Navigate to Redmine root
 cd "$(dirname "$0")/../../.."
@@ -36,7 +36,7 @@ run_test() {
 # Check if test database is setup
 if ! bundle exec rails runner -e test "puts 'Test DB OK'" >/dev/null 2>&1; then
     echo -e "${YELLOW}⚠️ Test database not setup. Running setup script...${NC}"
-    ./plugins/redmine_cloud_attachment_pro/test/setup_test_db.sh
+    ./plugins/redmine_cloud_attachment/test/setup_test_db.sh
 fi
 
 echo -e "${YELLOW}🚀 Starting test execution...${NC}"
@@ -46,7 +46,7 @@ failed_tests=0
 total_tests=0
 
 # Unit tests
-for test_file in plugins/redmine_cloud_attachment_pro/test/unit/*.rb; do
+for test_file in plugins/redmine_cloud_attachment/test/unit/*.rb; do
     if [ -f "$test_file" ]; then
         total_tests=$((total_tests + 1))
         if ! run_test "$test_file"; then
@@ -56,7 +56,7 @@ for test_file in plugins/redmine_cloud_attachment_pro/test/unit/*.rb; do
 done
 
 # Integration tests
-for test_file in plugins/redmine_cloud_attachment_pro/test/integration/*.rb; do
+for test_file in plugins/redmine_cloud_attachment/test/integration/*.rb; do
     if [ -f "$test_file" ]; then
         total_tests=$((total_tests + 1))
         if ! run_test "$test_file"; then

--- a/test/setup_test_db.sh
+++ b/test/setup_test_db.sh
@@ -3,7 +3,7 @@
 # Script to setup test database for Redmine plugin testing
 # Based on official Redmine Plugin Tutorial documentation
 
-echo "🚀 Setting up test database for redmine_cloud_attachment_pro plugin..."
+echo "🚀 Setting up test database for redmine_cloud_attachment plugin..."
 
 # Navigate to Redmine root
 cd "$(dirname "$0")/../../.."
@@ -25,6 +25,6 @@ bundle exec rake redmine:load_default_data
 
 echo "✅ Test database setup completed!"
 echo "💡 Now you can run tests with:"
-echo "   RAILS_ENV=test bundle exec rake test TEST=plugins/redmine_cloud_attachment_pro/test/unit/cloud_attachment_optimization_test.rb"
+echo "   RAILS_ENV=test bundle exec rake test TEST=plugins/redmine_cloud_attachment/test/unit/cloud_attachment_optimization_test.rb"
 echo "   Or run all plugin tests:"
-echo "   RAILS_ENV=test bundle exec rake redmine:plugins:test NAME=redmine_cloud_attachment_pro" 
+echo "   RAILS_ENV=test bundle exec rake redmine:plugins:test NAME=redmine_cloud_attachment" 

--- a/test/unit/basic_functionality_test.rb
+++ b/test/unit/basic_functionality_test.rb
@@ -13,7 +13,7 @@ class BasicFunctionalityTest < ActiveSupport::TestCase
 
   def test_plugin_loaded_correctly
     # Test that the plugin is loaded
-    assert Redmine::Plugin.registered_plugins.has_key?(:redmine_cloud_attachment_pro), 
+    assert Redmine::Plugin.registered_plugins.has_key?(:redmine_cloud_attachment), 
            "Plugin should be registered"
   end
 


### PR DESCRIPTION
## Summary
- Rename plugin id / folder / module from `redmine_cloud_attachment_pro` → `redmine_cloud_attachment`
- Display name: Redmine Cloud Attachment
- Version **1.2.0** with upgrade notes (`mv plugins/..._pro ...`)
- Config key `cloud_attachment` with fallback to legacy `cloud_attachment_pro`
- Canonical product URL: https://redmineshop.com/products/redmine-cloud-attachment

## Test plan
- [ ] Fresh install into `plugins/redmine_cloud_attachment`
- [ ] Upgrade path: rename old `_pro` folder and restart
- [ ] Presigned URL download still works on S3/GCS/Azure

Made with [Cursor](https://cursor.com)