### PR TITLE
fix: review findings, thumbnail 500, MinIO support (v1.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] — 2026-07-24
+
+### Added
+
+- S3-compatible / MinIO support via `s3.endpoint`, `s3.force_path_style`, and optional `s3.public_endpoint` for browser-reachable presigned URLs
+
 ## [1.2.1] — 2026-07-24
 
 ### Fixed
@@ -58,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Thumbnail generation for cloud-stored images
 - Compatible with Redmine 5.0.x and 6.x
 
+[1.2.2]: https://github.com/redmineshop/redmine_cloud_attachment/releases/tag/v1.2.2
 [1.2.1]: https://github.com/redmineshop/redmine_cloud_attachment/releases/tag/v1.2.1
 [1.2.0]: https://github.com/redmineshop/redmine_cloud_attachment/releases/tag/v1.2.0
 [1.1.1]: https://github.com/redmineshop/redmine_cloud_attachment/releases/tag/v1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] — 2026-07-24
+
+### Fixed
+
+- Azure credentials: accept both `storage_account_name` / `storage_access_key` (sample) and legacy `account_name` / `access_key`
+- Streaming uploads with chunked SHA256 — large files no longer load entirely into memory
+- Lazy-load cloud SDKs (`aws-sdk-s3`, `google-cloud-storage`, `azure-storage-blob`) only for the configured backend
+- README upgrade path from `redmine_cloud_attachment_pro` restored
+- `attachments:prefix_cloud_filenames` requires `CONFIRM=1` and documents the data risk
+- Controller/helper patches use `prepend` + `super`; remove double-include and `_pro` aliases
+- Apply patches via `after_initialize` on Zeitwerk (Redmine 6+) so methods load in production/test
+- Attachment patch uses `prepend` so local `readable?`/`thumbnail` call Redmine core via `super` (fixes 500 on `/attachments/thumbnail/...` with local storage)
+- Docs no longer claim an Admin → Plugins → Configure UI (config is YAML-only)
+
+### Changed
+
+- Pin `google-cloud-storage` to `~> 1.47`
+- S3 client supports IAM instance profile when access keys are omitted
+
 ## [1.2.0] — 2026-07-24
 
 ### Changed
@@ -39,5 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Thumbnail generation for cloud-stored images
 - Compatible with Redmine 5.0.x and 6.x
 
+[1.2.1]: https://github.com/redmineshop/redmine_cloud_attachment/releases/tag/v1.2.1
 [1.2.0]: https://github.com/redmineshop/redmine_cloud_attachment/releases/tag/v1.2.0
 [1.1.1]: https://github.com/redmineshop/redmine_cloud_attachment/releases/tag/v1.1.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
+
+# Cloud SDKs are loaded lazily at runtime based on Redmine::Configuration['storage'].
 gem 'aws-sdk-s3', '~> 1.0'
-gem 'google-cloud-storage'
+gem 'google-cloud-storage', '~> 1.47'
 gem 'azure-storage-blob', '~> 2.0'

--- a/README.md
+++ b/README.md
@@ -12,15 +12,19 @@ Store Redmine issue attachments in cloud object storage — AWS S3, Google Cloud
 
 - Route Redmine file uploads directly to AWS S3, GCS, or Azure Blob
 - Presigned URL downloads — files served directly from cloud, not through Redmine server
-- No local disk storage required (offload large attachments)
-- Configurable via `config/configuration.yml`
+- Streaming uploads (SHA256 digest without loading the whole file into memory)
+- Configurable via `config/configuration.yml` (no Admin UI settings page)
 - Compatible with Redmine's built-in attachment management UI
 
 ## Requirements
 
 - Redmine 5.0.x or 6.x
 - Ruby 3.0+
-- AWS S3 bucket (+ IAM credentials), GCS bucket, or Azure Storage account
+- AWS S3 bucket (+ IAM credentials or instance profile), GCS bucket, or Azure Storage account
+
+### IAM (S3) minimum
+
+Grant `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject` on your attachments bucket/prefix.
 
 ## Installation
 
@@ -28,17 +32,18 @@ Download the SHA256-verified package from [RedmineShop](https://redmineshop.com/
 
 ```bash
 # From your Redmine root
-tar -xzf redmine_cloud_attachment-1.2.0.tar.gz -C plugins/
-bundle exec rake redmine:plugins:migrate RAILS_ENV=production
+tar -xzf redmine_cloud_attachment-1.2.1.tar.gz -C plugins/
+bundle install
 # Restart your Redmine server
 ```
 
 See the [install guide](https://redmineshop.com/docs/cloud-attachment-install) for full instructions.
 
-### Upgrading from `redmine_cloud_attachment`
+### Upgrading from `redmine_cloud_attachment_pro` (≤ 1.1.x)
 
 ```bash
-mv plugins/redmine_cloud_attachment plugins/redmine_cloud_attachment
+mv plugins/redmine_cloud_attachment_pro plugins/redmine_cloud_attachment
+bundle install
 # Restart Redmine
 ```
 
@@ -46,7 +51,7 @@ Optional: rename `cloud_attachment_pro:` → `cloud_attachment:` in `configurati
 
 ## Configuration
 
-Edit `config/configuration.yml` (see `config/configuration.yml.sample`):
+Edit `config/configuration.yml` (see `config/configuration.yml.sample`). There is **no** “Configure” link under Administration → Plugins for this plugin.
 
 ### AWS S3 example
 
@@ -59,11 +64,12 @@ production:
     secret_access_key: <%= ENV["AWS_SECRET_KEY"] %>
     bucket: <%= ENV["REDMINE_FILES_ATTACHEMENT_S3_BUCKET"] %>
     region: <%= ENV["AWS_REGION"] %>
-    path: <%= ENV["AWS_PATH"] %>
-  # Optional plugin settings (legacy key cloud_attachment_pro also accepted):
+    path: redmine/files
   cloud_attachment:
     presigned_url_expires_in: 15
 ```
+
+Presigned download URLs expire after the configured minutes (default 15). Do not treat them as permanent links.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Download the SHA256-verified package from [RedmineShop](https://redmineshop.com/
 
 ```bash
 # From your Redmine root
-tar -xzf redmine_cloud_attachment-1.2.1.tar.gz -C plugins/
+tar -xzf redmine_cloud_attachment-1.2.2.tar.gz -C plugins/
 bundle install
 # Restart your Redmine server
 ```
@@ -70,6 +70,27 @@ production:
 ```
 
 Presigned download URLs expire after the configured minutes (default 15). Do not treat them as permanent links.
+
+### MinIO / S3-compatible example
+
+```yaml
+production:
+  storage: :s3
+  s3:
+    enabled: true
+    access_key_id: minioadmin
+    secret_access_key: minioadmin
+    bucket: redmine-attachments
+    region: us-east-1
+    path: redmine/files
+    endpoint: http://minio:9000
+    # Host the browser can reach for presigned downloads (optional but required in Docker)
+    public_endpoint: http://localhost:9000
+    force_path_style: true
+```
+
+`endpoint` is used for put/get/delete from the Redmine process. When `public_endpoint` is set,
+presigned download URLs are signed against that host instead (so redirects work outside Docker).
 
 ## Troubleshooting
 

--- a/config/configuration.yml.sample
+++ b/config/configuration.yml.sample
@@ -5,18 +5,26 @@ production:
   storage: :s3 # or :gcs or :azure or :local
   s3:
     enabled: true
+    # Optional when using IAM instance profile / task role:
     access_key_id: <%= ENV["AWS_ACCESS_KEY"] %>
     secret_access_key: <%= ENV["AWS_SECRET_KEY"] %>
     bucket: <%= ENV["REDMINE_FILES_ATTACHEMENT_S3_BUCKET"] %>
     region: <%= ENV["AWS_REGION"] %>
-    path: <%= ENV["AWS_PATH"] %>
+    path: <%= ENV["AWS_PATH"] || "redmine/files" %>
   gcs:
     project_id: "your-gcp-project"
     bucket: "your-gcs-bucket"
     gcs_credentials: "/path/to/your/service_account.json"
     path: "redmine/files"
   azure:
+    # Both naming styles are accepted by the plugin:
     storage_account_name: "your-storage-account-name"
     storage_access_key: "your-storage-access-key"
+    # account_name: "your-storage-account-name"
+    # access_key: "your-storage-access-key"
     container: "your-container-name"
     path: "redmine/files"
+  # Optional plugin settings (legacy key cloud_attachment_pro also accepted):
+  cloud_attachment:
+    # Presigned URL lifetime in minutes (default 15)
+    presigned_url_expires_in: 15

--- a/config/configuration.yml.sample
+++ b/config/configuration.yml.sample
@@ -1,8 +1,30 @@
+# Default / development: local disk (no cloud).
+# Switch development to MinIO (S3-compatible) using the block below — see demo stack.
+default:
+  email_delivery:
+
 development:
   storage: :local
 
+  # --- MinIO (S3-compatible) — uncomment to use demo MinIO ---
+  # storage: :s3
+  # s3:
+  #   enabled: true
+  #   access_key_id: "minioadmin"
+  #   secret_access_key: "minioadmin"
+  #   bucket: "redmine-attachments"
+  #   region: "us-east-1"
+  #   path: "redmine/files"
+  #   # Redmine container → MinIO on Docker network
+  #   endpoint: "http://demo-minio:9000"
+  #   # Browser-facing host for presigned download URLs
+  #   public_endpoint: "http://localhost:9000"
+  #   force_path_style: true
+  # cloud_attachment:
+  #   presigned_url_expires_in: 15
+
 production:
-  storage: :s3 # or :gcs or :azure or :local
+  storage: :s3 # or :gcs or :azure or :local or MinIO via endpoint below
   s3:
     enabled: true
     # Optional when using IAM instance profile / task role:
@@ -11,6 +33,10 @@ production:
     bucket: <%= ENV["REDMINE_FILES_ATTACHEMENT_S3_BUCKET"] %>
     region: <%= ENV["AWS_REGION"] %>
     path: <%= ENV["AWS_PATH"] || "redmine/files" %>
+    # MinIO / S3-compatible (optional):
+    # endpoint: "http://minio:9000"
+    # public_endpoint: "https://files.example.com"  # host browsers can reach
+    # force_path_style: true
   gcs:
     project_id: "your-gcp-project"
     bucket: "your-gcs-bucket"

--- a/init.rb
+++ b/init.rb
@@ -6,97 +6,55 @@ require_relative 'lib/redmine_cloud_attachment/version'
 
 Redmine::Plugin.register :redmine_cloud_attachment do
   name 'Redmine Cloud Attachment'
-  author 'RedmineShop (based on railsfactory/redmine_cloud_attachment)'
+  author 'RedmineShop (based on railsfactory/redmine_cloud_attachment_pro)'
   description 'Store Redmine attachments in AWS S3, Google Cloud Storage, or Azure Blob — with presigned URL support for secure direct downloads.'
   version RedmineCloudAttachment::VERSION
   url 'https://redmineshop.com/products/redmine-cloud-attachment'
   author_url 'https://redmineshop.com'
+end
 
-  # Rails.logger.info "[CloudAttachment INIT] Inside plugin registration block."
+module RedmineCloudAttachment
+  module Boot
+    module_function
 
-  # Plugin settings definition (if any)
-  # settings default: { 'setting_key' => 'default_value' }, partial: 'settings/rcap_settings'
+    def apply_patches
+      plugin_dir = Redmine::Plugin.find(:redmine_cloud_attachment).directory
 
-  # Rails.logger.info "[CloudAttachment INIT] Attempting to load and apply patches directly."
+      require_dependency File.join(plugin_dir, 'lib', 'redmine_cloud_attachment', 'attachment_patch')
+      require_dependency File.join(
+        plugin_dir, 'lib', 'redmine_cloud_attachment', 'patches', 'attachments_controller_patch'
+      )
+      require_dependency File.join(
+        plugin_dir, 'lib', 'redmine_cloud_attachment', 'patches', 'attachments_helper_patch'
+      )
 
-  # Ensure Attachment class is loaded before patching
-  begin
-    require_dependency 'attachment' # Core Redmine class
-    patch_module_fqn = 'RedmineCloudAttachment::AttachmentPatch'
-    patch_file_path = File.join(File.dirname(__FILE__), 'lib', 'redmine_cloud_attachment', 'attachment_patch.rb')
-    # Rails.logger.info "[CloudAttachment INIT] Requiring AttachmentPatch from: #{patch_file_path}"
-    require_dependency patch_file_path
-    # Rails.logger.info "[CloudAttachment INIT] Successfully required AttachmentPatch."
+      unless Attachment.ancestors.include?(RedmineCloudAttachment::AttachmentPatch)
+        Attachment.prepend RedmineCloudAttachment::AttachmentPatch
+      end
 
-    patch_module = patch_module_fqn.constantize
-    target_class = Attachment
+      unless AttachmentsController.ancestors.include?(
+        RedmineCloudAttachment::Patches::AttachmentsControllerPatch
+      )
+        AttachmentsController.prepend RedmineCloudAttachment::Patches::AttachmentsControllerPatch
+      end
 
-    unless target_class.included_modules.include?(patch_module)
-      target_class.send(:include, patch_module)
-      # Rails.logger.info "[CloudAttachment INIT] Successfully patched Attachment model with #{patch_module_fqn}."
-    # else
-      # Rails.logger.info "[CloudAttachment INIT] Attachment model already includes #{patch_module_fqn}."
+      unless AttachmentsHelper.ancestors.include?(
+        RedmineCloudAttachment::Patches::AttachmentsHelperPatch
+      )
+        AttachmentsHelper.prepend RedmineCloudAttachment::Patches::AttachmentsHelperPatch
+      end
     end
-  rescue LoadError => e
-    Rails.logger.error "[CloudAttachment] Error loading/applying AttachmentPatch. Message: #{e.message}"
-  rescue NameError => e
-    Rails.logger.error "[CloudAttachment] Error finding Attachment or AttachmentPatch module. Message: #{e.message}"
-  rescue StandardError => e
-    Rails.logger.error "[CloudAttachment] General error applying AttachmentPatch. Message: #{e.message}"
   end
+end
 
-  # Ensure AttachmentsController is loaded before patching
-  begin
-    require_dependency 'attachments_controller' # Core Redmine class
-    controller_patch_fqn = 'RedmineCloudAttachment::Patches::AttachmentsControllerPatch'
-    controller_patch_path = File.join(File.dirname(__FILE__), 'lib', 'redmine_cloud_attachment', 'patches', 'attachments_controller_patch.rb')
-    # Rails.logger.info "[CloudAttachment INIT] Requiring AttachmentsControllerPatch from: #{controller_patch_path}"
-    require_dependency controller_patch_path
-    # Rails.logger.info "[CloudAttachment INIT] Successfully required AttachmentsControllerPatch."
-
-    patch_module = controller_patch_fqn.constantize
-    target_controller = AttachmentsController
-
-    unless target_controller.included_modules.include?(patch_module)
-      target_controller.send(:include, patch_module) # Using include, ensure patch uses `included do` or `prepended do` as appropriate
-      # Rails.logger.info "[CloudAttachment INIT] Successfully patched AttachmentsController with #{controller_patch_fqn}."
-    # else
-      # Rails.logger.info "[CloudAttachment INIT] AttachmentsController already includes #{controller_patch_fqn}."
-    end
-  rescue LoadError => e
-    Rails.logger.error "[CloudAttachment] Error loading/applying AttachmentsControllerPatch. Message: #{e.message}"
-  rescue NameError => e
-    Rails.logger.error "[CloudAttachment] Error finding AttachmentsController or its patch module. Message: #{e.message}"
-  rescue StandardError => e
-    Rails.logger.error "[CloudAttachment] General error applying AttachmentsControllerPatch. Message: #{e.message}"
+# Zeitwerk (Redmine 6+): apply after full boot. Classic: re-apply on each reload.
+if Rails.version > '6.0' && Rails.autoloaders.zeitwerk_enabled?
+  Rails.application.config.after_initialize do
+    RedmineCloudAttachment::Boot.apply_patches
   end
-
-  # Ensure AttachmentsHelper is loaded before patching
-  begin
-    require_dependency 'attachments_helper' # Core Redmine helper
-    helper_patch_fqn = 'RedmineCloudAttachment::Patches::AttachmentsHelperPatch'
-    helper_patch_path = File.join(File.dirname(__FILE__), 'lib', 'redmine_cloud_attachment', 'patches', 'attachments_helper_patch.rb')
-    require_dependency helper_patch_path
-
-    patch_module = helper_patch_fqn.constantize
-    target_helper = AttachmentsHelper
-
-    unless target_helper.included_modules.include?(patch_module)
-      target_helper.send(:include, patch_module)
-      Rails.logger.debug "[CloudAttachment] Successfully patched AttachmentsHelper with #{helper_patch_fqn}."
-    end
-
-    # Also patch ApplicationHelper for thumbnail_path method
-    ApplicationHelper.send(:include, patch_module) unless ApplicationHelper.included_modules.include?(patch_module)
-  rescue LoadError => e
-    Rails.logger.error "[CloudAttachment] Error loading/applying AttachmentsHelperPatch. Message: #{e.message}"
-  rescue NameError => e
-    Rails.logger.error "[CloudAttachment] Error finding AttachmentsHelper or its patch module. Message: #{e.message}"
-  rescue StandardError => e
-    Rails.logger.error "[CloudAttachment] General error applying AttachmentsHelperPatch. Message: #{e.message}"
+else
+  reloader = Rails.version > '5' ? ActiveSupport::Reloader : ActionDispatch::Callbacks
+  reloader.to_prepare do
+    RedmineCloudAttachment::Boot.apply_patches
   end
-
-  # Note: optimization_test.rb moved to test/ directory
-
-  # Rails.logger.info "[CloudAttachment INIT] Exiting plugin registration block after attempting direct patch loading."
 end

--- a/lib/redmine_cloud_attachment/attachment_patch.rb
+++ b/lib/redmine_cloud_attachment/attachment_patch.rb
@@ -302,16 +302,47 @@ module RedmineCloudAttachment
       require 'azure/storage/blob'
     end
 
+    # Builds Aws::S3::Client options. Supports MinIO / S3-compatible stores via:
+    #   endpoint, public_endpoint, force_path_style
+    def s3_client_options(endpoint: nil)
+      opts = { region: cloud_config['region'].presence || 'us-east-1' }
+      if cloud_config['access_key_id'].present?
+        opts[:access_key_id] = cloud_config['access_key_id']
+        opts[:secret_access_key] = cloud_config['secret_access_key']
+      end
+
+      resolved_endpoint = endpoint.presence || cloud_config['endpoint'].presence
+      if resolved_endpoint.present?
+        opts[:endpoint] = resolved_endpoint
+        # Path-style is required for MinIO and most S3-compatible endpoints.
+        opts[:force_path_style] = s3_force_path_style?
+      elsif !cloud_config['force_path_style'].nil?
+        opts[:force_path_style] = s3_force_path_style?
+      end
+
+      opts
+    end
+
+    def s3_force_path_style?
+      value = cloud_config['force_path_style']
+      return true if value.nil? && cloud_config['endpoint'].present?
+
+      ActiveModel::Type::Boolean.new.cast(value)
+    end
+
     def s3_client
       require_s3!
-      @s3_client ||= begin
-        opts = { region: cloud_config['region'] }
-        if cloud_config['access_key_id'].present?
-          opts[:access_key_id] = cloud_config['access_key_id']
-          opts[:secret_access_key] = cloud_config['secret_access_key']
-        end
-        Aws::S3::Client.new(opts)
-      end
+      @s3_client ||= Aws::S3::Client.new(s3_client_options)
+    end
+
+    # Browser-facing presigns must use a host the client can reach (e.g. localhost),
+    # while Redmine itself talks to the Docker service name (demo-minio).
+    def s3_presign_client
+      require_s3!
+      public_endpoint = cloud_config['public_endpoint'].presence
+      return s3_client if public_endpoint.blank? || public_endpoint == cloud_config['endpoint']
+
+      @s3_presign_client ||= Aws::S3::Client.new(s3_client_options(endpoint: public_endpoint))
     end
 
     def s3_bucket
@@ -346,7 +377,7 @@ module RedmineCloudAttachment
       return nil unless storage_backend == :s3 && cloud_config['bucket'].present?
 
       require_s3!
-      signer = Aws::S3::Presigner.new(client: s3_client)
+      signer = Aws::S3::Presigner.new(client: s3_presign_client)
       signer.presigned_url(
         :get_object,
         bucket: s3_bucket,

--- a/lib/redmine_cloud_attachment/attachment_patch.rb
+++ b/lib/redmine_cloud_attachment/attachment_patch.rb
@@ -1,392 +1,427 @@
-require 'aws-sdk-s3'
-require 'google/cloud/storage'
-require 'azure/storage/blob'
+# frozen_string_literal: true
+
 require_dependency 'attachment'
 
 module RedmineCloudAttachment
+  # Prepended onto Attachment so `super` reaches Redmine core methods.
+  # Do NOT use include + class_eval to redefine methods — that breaks `super`.
   module AttachmentPatch
-    def self.included(base)
+    def self.prepended(base)
       base.class_eval do
         after_destroy :delete_from_cloud
         before_destroy :cleanup_temp_file
+      end
+    end
 
-        # Method to generate a direct download URL (e.g., S3 presigned URL)
-        # Returns the presigned URL if available, otherwise nil.
-        def direct_download_url(expires_in = 15.minutes)
-          return nil unless cloud_diskfile?
-          
-          case storage_backend
-          when :s3
-            s3_presigned_url(expires_in)
-          when :gcs
-            gcs_presigned_url(expires_in)
-          when :azure
-            azure_presigned_url(expires_in)
-          else
-            nil
+    # Returns a time-limited direct URL for cloud-backed attachments, or nil.
+    def direct_download_url(expires_in = 15.minutes)
+      return nil unless cloud_diskfile?
+
+      case storage_backend
+      when :s3
+        s3_presigned_url(expires_in)
+      when :gcs
+        gcs_presigned_url(expires_in)
+      when :azure
+        azure_presigned_url(expires_in)
+      end
+    end
+
+    def files_to_final_location
+      return super if configured_storage == :local
+      return unless @temp_file
+
+      sha = Digest::SHA256.new
+      self.disk_directory = target_directory
+      upload_and_digest(@temp_file, sha)
+      self.digest = sha.hexdigest
+      @temp_file = nil
+      set_content_type
+    end
+
+    def diskfile
+      return super unless cloud_diskfile?
+
+      Rails.logger.info(
+        "[CloudAttachment] diskfile() called for cloud attachment #{id} — prefer direct_download_url()"
+      )
+
+      return @cached_temp_diskfile if @cached_temp_diskfile && File.exist?(@cached_temp_diskfile)
+
+      cleanup_temp_file
+
+      @temp_file_obj = Tempfile.create(['redmine', File.extname(cloud_key.to_s)])
+      @temp_file_obj.binmode
+      begin
+        download_from_cloud(@temp_file_obj)
+        @temp_file_obj.rewind
+        @cached_temp_diskfile = @temp_file_obj.path
+      rescue StandardError => e
+        Rails.logger.error(
+          "[CloudAttachment] Fallback to local for attachment #{id} due to cloud download error: #{e.message}"
+        )
+        cleanup_temp_file
+        return super
+      end
+
+      @cached_temp_diskfile
+    end
+
+    def delete_from_cloud
+      return unless cloud_diskfile?
+
+      delete_from_backend(cloud_key)
+    rescue StandardError => e
+      Rails.logger.error(
+        "[CloudAttachment] Failed to delete #{cloud_key} from cloud for attachment #{id}: #{e.message}"
+      )
+    end
+
+    def readable?
+      return super unless cloud_diskfile?
+      return false unless disk_filename.present?
+
+      case storage_backend
+      when :s3
+        cloud_config['bucket'].present? &&
+          (cloud_config['access_key_id'].present? || iam_role_credentials?)
+      when :gcs
+        cloud_config['bucket'].present? && cloud_config['project_id'].present?
+      when :azure
+        cloud_config['container'].present? && azure_account_name.present?
+      else
+        false
+      end
+    end
+
+    def thumbnail(options = {})
+      return super unless cloud_diskfile?
+
+      Rails.logger.debug("[CloudAttachment] Generating thumbnail for cloud attachment #{id}")
+
+      return unless thumbnailable? && readable?
+
+      size = options[:size].to_i
+      if size > 0
+        size = (size / 50.0).ceil * 50
+        size = 800 if size > 800
+      else
+        size = Setting.thumbnails_size.to_i
+      end
+      size = 100 unless size > 0
+      target = thumbnail_path(size)
+      return target if File.exist?(target)
+
+      begin
+        source_file = diskfile
+        result = Redmine::Thumbnail.generate(source_file, target, size, is_pdf?)
+        cleanup_after_thumbnail
+        result
+      rescue StandardError => e
+        cleanup_after_thumbnail
+        logger&.error(
+          "[CloudAttachment] Thumbnail failed for cloud attachment #{id}: #{e.message}"
+        )
+        nil
+      end
+    end
+
+    def cloud_expiry_time
+      plugin_cfg = Redmine::Configuration['cloud_attachment'] ||
+                   Redmine::Configuration['cloud_attachment_pro']
+      if plugin_cfg && plugin_cfg['presigned_url_expires_in']
+        plugin_cfg['presigned_url_expires_in'].to_i.minutes
+      else
+        15.minutes
+      end
+    end
+
+    def cloud_diskfile?
+      disk_filename.to_s.match?(/^(s3|gcs|azure)_/)
+    end
+
+    def storage_backend
+      return @storage_backend if defined?(@storage_backend)
+
+      @storage_backend =
+        if cloud_diskfile?
+          case disk_filename.to_s
+          when /^s3_/ then :s3
+          when /^gcs_/ then :gcs
+          when /^azure_/ then :azure
+          else :local
           end
+        else
+          configured_storage
+        end
+    end
+
+    private
+
+    def configured_storage
+      Redmine::Configuration['storage']&.to_sym || :local
+    end
+
+    def upload_and_digest(temp_file, sha)
+      path = materialize_upload_path(temp_file, sha)
+      key = build_upload_key
+
+      case storage_backend
+      when :s3
+        require_s3!
+        File.open(path, 'rb') do |io|
+          s3_client.put_object(bucket: s3_bucket, key: key, body: io)
+        end
+      when :gcs
+        require_gcs!
+        gcs_bucket.create_file(path, key)
+      when :azure
+        require_azure!
+        File.open(path, 'rb') do |io|
+          azure_blob_client.create_block_blob(azure_container, key, io)
+        end
+      else
+        return
+      end
+
+      self.disk_filename = "#{storage_backend}_#{File.basename(key)}"
+    end
+
+    # Hash file in chunks and return a filesystem path suitable for SDK uploads.
+    def materialize_upload_path(temp_file, sha)
+      path =
+        if temp_file.respond_to?(:path) && temp_file.path.present? && File.file?(temp_file.path)
+          temp_file.path
+        else
+          tmp = Tempfile.new(['redmine-upload', File.extname(filename.to_s)])
+          tmp.binmode
+          data = temp_file.respond_to?(:read) ? temp_file.tap(&:rewind).read : temp_file.to_s
+          tmp.write(data)
+          tmp.flush
+          tmp.close
+          @upload_temp_to_unlink = tmp.path
+          tmp.path
         end
 
-
-
-        def files_to_final_location
-          return unless @temp_file
-
-          sha = Digest::SHA256.new
-          content = read_temp_file(@temp_file, sha)
-          self.disk_directory = target_directory
-
-          upload_content(content)
-
-          self.digest = sha.hexdigest
-          @temp_file = nil
-
-          set_content_type
-        end
-
-        def diskfile
-          return local_diskfile unless cloud_diskfile?
-
-          # Log usage for monitoring - this should be rarely called if direct downloads are working
-          Rails.logger.info("[CloudAttachment] diskfile() called for cloud attachment #{self.id} - consider using direct_download_url() for better performance")
-
-          # Use instance variable to cache the temp file path per request/instance
-          return @cached_temp_diskfile if @cached_temp_diskfile && File.exist?(@cached_temp_diskfile)
-
-          # Clean up any existing temp file first
-          cleanup_temp_file
-
-          @temp_file_obj = Tempfile.create(["redmine", File.extname(cloud_key)])
-          @temp_file_obj.binmode
-          begin
-            download_from_cloud(@temp_file_obj)
-            @temp_file_obj.rewind
-            @cached_temp_diskfile = @temp_file_obj.path
-          rescue => e
-            Rails.logger.error("[CloudAttachment] Fallback to local for attachment #{self.id} due to cloud download error: #{e.message}")
-            cleanup_temp_file
-            return local_diskfile
-          end
-
-          @cached_temp_diskfile
-        end
-
-        def delete_from_cloud
-          return unless cloud_diskfile?
-
-          begin
-            delete_from_backend(cloud_key)
-          rescue => e
-            Rails.logger.error("[CloudAttachment] Failed to delete #{cloud_key} from cloud for attachment #{self.id}: #{e.message}")
-          end
-        end
-
-        # Override readable? method to optimize for cloud files
-        def readable?
-          return super unless cloud_diskfile?
-          
-          # For cloud files, check if disk_filename exists and cloud backend is configured
-          return false unless disk_filename.present?
-          
-          case storage_backend
-          when :s3
-            cloud_config['bucket'].present? && cloud_config['access_key_id'].present?
-          when :gcs
-            cloud_config['bucket'].present? && cloud_config['project_id'].present?
-          when :azure
-            cloud_config['container'].present? && cloud_config['account_name'].present?
-          else
-            false
-          end
-        end
-
-        # Override thumbnail method to optimize for cloud files
-        def thumbnail(options={})
-          if cloud_diskfile?
-            # For cloud files, we need to download and generate thumbnail locally
-            # But we'll cache it to avoid repeated downloads
-            Rails.logger.debug("[CloudAttachment] Generating thumbnail for cloud attachment #{self.id}")
-            
-            if thumbnailable? && readable?
-              size = options[:size].to_i
-              if size > 0
-                # Limit the number of thumbnails per image
-                size = (size / 50.0).ceil * 50
-                # Maximum thumbnail size
-                size = 800 if size > 800
-              else
-                size = Setting.thumbnails_size.to_i
-              end
-              size = 100 unless size > 0
-              target = thumbnail_path(size)
-
-              # Check if thumbnail already exists
-              return target if File.exist?(target)
-
-              begin
-                # Download cloud file to temp location for thumbnail generation
-                source_file = diskfile # This will create temp file from cloud
-                result = Redmine::Thumbnail.generate(source_file, target, size, is_pdf?)
-                
-                # Clean up temp file after thumbnail generation
-                cleanup_after_thumbnail
-                
-                return result
-              rescue => e
-                # Clean up temp file even if generation fails
-                cleanup_after_thumbnail
-                
-                if logger
-                  logger.error(
-                    "[CloudAttachment] An error occurred while generating thumbnail for cloud attachment #{self.id}: #{e.message}"
-                  )
-                end
-                return nil
-              end
-            end
-          else
-            # Use original logic for local files
-            super
-          end
-        end
-
-        # Helper method to get expiry time from configuration
-        def cloud_expiry_time
-          plugin_cfg = Redmine::Configuration['cloud_attachment'] ||
-                       Redmine::Configuration['cloud_attachment_pro']
-          if plugin_cfg && plugin_cfg['presigned_url_expires_in']
-            plugin_cfg['presigned_url_expires_in'].to_i.minutes
-          else
-            15.minutes
-          end
-        end
-
-        # Check if attachment is stored in cloud
-        def cloud_diskfile?
-          disk_filename.to_s.match?(/^(s3|gcs|azure)_[^_]+_/)
-        end
-
-        # Get storage backend type based on configuration
-        def storage_backend
-          return @storage_backend if defined?(@storage_backend)
-          
-          @storage_backend = if cloud_diskfile?
-            case disk_filename.to_s
-            when /^s3_/
-              :s3
-            when /^gcs_/
-              :gcs  
-            when /^azure_/
-              :azure
-            else
-              :local
-            end
-          else
-            Redmine::Configuration["storage"]&.to_sym || :local
-          end
-        end
-
-        private
-
-        def upload_content(content)
-          key = cloud_key
-
-          case storage_backend
-          when :s3
-            s3_client.put_object(bucket: s3_bucket, key: key, body: content)
-          when :gcs
-            gcs_bucket.create_file(StringIO.new(content), key)
-          when :azure
-            azure_blob_client.create_block_blob(azure_container, key, content)
-          else
-            save_locally(content)
-            return
-          end
-
-          self.disk_filename = "#{storage_backend}_#{File.basename(key)}"
-        end
-
-        def download_from_cloud(tmp)
-          case storage_backend
-          when :s3
-            s3_client.get_object(bucket: s3_bucket, key: cloud_key) { |chunk| tmp.write(chunk) }
-          when :gcs
-            gcs_bucket.file(cloud_key)&.download(tmp.path)
-          when :azure
-            _, content = azure_blob_client.get_blob(azure_container, cloud_key)
-            tmp.write(content)
-          end
-        end
-
-        def delete_from_backend(key)
-          case storage_backend
-          when :s3
-            s3_client.delete_object(bucket: s3_bucket, key: key)
-          when :gcs
-            gcs_bucket.file(key)&.delete
-          when :azure
-            azure_blob_client.delete_blob(azure_container, key)
-          end
-        end
-
-        def save_locally(content)
-          Attachment.create_diskfile(filename, disk_directory) do |f|
-            self.disk_filename = File.basename(f.path)
-            f.write(content)
-          end
-        end
-
-        def set_content_type
-          if content_type.blank? && filename.present?
-            self.content_type = Redmine::MimeType.of(filename)
-          end
-          self.content_type = nil if content_type&.length.to_i > 255
-        end
-
-        def read_temp_file(temp_file, sha)
-          content = temp_file.respond_to?(:read) ? temp_file.tap(&:rewind).read : temp_file.to_s
-          sha.update(content)
-          content
-        end
-
-        def cloud_filename
-          disk_filename.presence || "#{SecureRandom.hex}_#{filename}"
-        end
-
-        def cloud_key
-          prefix = "#{storage_backend}_"
-          key = File.join(cloud_base_path, created_on.strftime('%Y/%m'), cloud_filename)
-          cloud_diskfile? ? key.sub(/#{prefix}/, '') : key
-        end
-
-        def local_diskfile
-          File.join(self.class.storage_path, disk_directory.to_s, disk_filename.to_s)
-        end
-
-
-
-        def cloud_config
-          Redmine::Configuration[storage_backend.to_s] || {}
-        end
-
-        def cloud_base_path
-          cloud_config['path'] || 'redmine/files'
-        end
-
-        def s3_client
-          @s3_client ||= Aws::S3::Client.new(
-            access_key_id: cloud_config['access_key_id'],
-            secret_access_key: cloud_config['secret_access_key'],
-            region: cloud_config['region']
-          )
-        end
-
-        def s3_bucket
-          cloud_config['bucket']
-        end
-
-        def gcs_client
-          @gcs_client ||= Google::Cloud::Storage.new(
-            project_id: cloud_config['project_id'],
-            credentials: cloud_config['gcs_credentials']
-          )
-        end
-
-        def gcs_bucket
-          @gcs_bucket ||= gcs_client.bucket(cloud_config['bucket'])
-        end
-
-        def azure_blob_client
-          @azure_blob_client ||= Azure::Storage::Blob::BlobService.create(
-            storage_account_name: cloud_config['account_name'],
-            storage_access_key: cloud_config['access_key']
-          )
-        end
-
-        def azure_container
-          cloud_config['container']
-        end
-
-        def s3_presigned_url(expires_in = 15.minutes)
-          unless storage_backend == :s3 && cloud_config['bucket'].present?
-            return nil
-          end
-
-          begin
-            signer = Aws::S3::Presigner.new(client: s3_client)
-            url = signer.presigned_url(:get_object, bucket: s3_bucket, key: cloud_key, expires_in: expires_in.to_i)
-            Rails.logger.debug("[CloudAttachment] Generated S3 presigned URL for attachment #{self.id}")
-            url
-          rescue => e
-            Rails.logger.error("[CloudAttachment] Failed to generate S3 presigned URL for #{cloud_key} (attachment #{self.id}): #{e.message}")
-            nil
-          end
-        end
-
-        def gcs_presigned_url(expires_in = 15.minutes)
-          unless storage_backend == :gcs && cloud_config['bucket'].present?
-            return nil
-          end
-
-          begin
-            file = gcs_bucket.file(cloud_key)
-            return nil unless file
-            
-            url = file.signed_url(method: "GET", expires: expires_in.to_i)
-            Rails.logger.debug("[CloudAttachment] Generated GCS presigned URL for attachment #{self.id}")
-            url
-          rescue => e
-            Rails.logger.error("[CloudAttachment] Failed to generate GCS presigned URL for #{cloud_key} (attachment #{self.id}): #{e.message}")
-            nil
-          end
-        end
-
-        def azure_presigned_url(expires_in = 15.minutes)
-          unless storage_backend == :azure && cloud_config['container'].present?
-            return nil
-          end
-
-          begin
-            # Azure Blob Storage presigned URL (SAS token)
-            start_time = Time.now.utc
-            expiry_time = start_time + expires_in.to_i
-            
-            sas_token = azure_blob_client.generate_blob_sas_token(
-              azure_container,
-              cloud_key,
-              permission: 'r', # Read permission
-              start_time: start_time.iso8601,
-              expiry_time: expiry_time.iso8601
-            )
-            
-            url = azure_blob_client.generate_uri("#{azure_container}/#{cloud_key}") + "?#{sas_token}"
-            Rails.logger.debug("[CloudAttachment] Generated Azure presigned URL for attachment #{self.id}")
-            url
-          rescue => e
-            Rails.logger.error("[CloudAttachment] Failed to generate Azure presigned URL for #{cloud_key} (attachment #{self.id}): #{e.message}")
-            nil
-          end
-        end
-
-        # Clean up temporary file
-        def cleanup_temp_file
-          if @temp_file_obj && !@temp_file_obj.closed?
-            @temp_file_obj.close
-            @temp_file_obj.unlink rescue nil
-          end
-          @temp_file_obj = nil
-          @cached_temp_diskfile = nil
-        end
-
-        # Clean up temp files after thumbnail generation
-        def cleanup_after_thumbnail
-          cleanup_temp_file
-          Rails.logger.debug("[CloudAttachment] Cleaned up temp files after thumbnail generation for attachment #{self.id}")
+      File.open(path, 'rb') do |io|
+        while (chunk = io.read(1024 * 1024))
+          sha.update(chunk)
         end
       end
+
+      path
+    end
+
+    def build_upload_key
+      stamp = (created_on || Time.current).strftime('%Y/%m')
+      base = disk_filename.presence || "#{SecureRandom.hex}_#{filename}"
+      File.join(cloud_base_path, stamp, base)
+    end
+
+    def download_from_cloud(tmp)
+      case storage_backend
+      when :s3
+        require_s3!
+        s3_client.get_object(bucket: s3_bucket, key: cloud_key) { |chunk| tmp.write(chunk) }
+      when :gcs
+        require_gcs!
+        gcs_bucket.file(cloud_key)&.download(tmp.path)
+      when :azure
+        require_azure!
+        _props, content = azure_blob_client.get_blob(azure_container, cloud_key)
+        tmp.write(content)
+      end
+    end
+
+    def delete_from_backend(key)
+      case storage_backend
+      when :s3
+        require_s3!
+        s3_client.delete_object(bucket: s3_bucket, key: key)
+      when :gcs
+        require_gcs!
+        gcs_bucket.file(key)&.delete
+      when :azure
+        require_azure!
+        azure_blob_client.delete_blob(azure_container, key)
+      end
+    end
+
+    def set_content_type
+      if content_type.blank? && filename.present?
+        self.content_type = Redmine::MimeType.of(filename)
+      end
+      self.content_type = nil if content_type&.length.to_i > 255
+    end
+
+    def cloud_filename
+      disk_filename.presence || "#{SecureRandom.hex}_#{filename}"
+    end
+
+    def cloud_key
+      prefix = "#{storage_backend}_"
+      key = File.join(
+        cloud_base_path,
+        (created_on || Time.current).strftime('%Y/%m'),
+        cloud_filename
+      )
+      cloud_diskfile? ? key.sub(prefix, '') : key
+    end
+
+    def cloud_config
+      Redmine::Configuration[storage_backend.to_s] || {}
+    end
+
+    def cloud_base_path
+      cloud_config['path'] || 'redmine/files'
+    end
+
+    def iam_role_credentials?
+      # Allow EC2/ECS instance profiles when explicit keys are omitted.
+      cloud_config['access_key_id'].blank? && cloud_config['secret_access_key'].blank?
+    end
+
+    # Accept both sample keys (storage_account_name) and legacy short keys (account_name).
+    def azure_account_name
+      cloud_config['account_name'].presence || cloud_config['storage_account_name']
+    end
+
+    def azure_access_key
+      cloud_config['access_key'].presence || cloud_config['storage_access_key']
+    end
+
+    def require_s3!
+      require 'aws-sdk-s3'
+    end
+
+    def require_gcs!
+      require 'google/cloud/storage'
+    end
+
+    def require_azure!
+      require 'azure/storage/blob'
+    end
+
+    def s3_client
+      require_s3!
+      @s3_client ||= begin
+        opts = { region: cloud_config['region'] }
+        if cloud_config['access_key_id'].present?
+          opts[:access_key_id] = cloud_config['access_key_id']
+          opts[:secret_access_key] = cloud_config['secret_access_key']
+        end
+        Aws::S3::Client.new(opts)
+      end
+    end
+
+    def s3_bucket
+      cloud_config['bucket']
+    end
+
+    def gcs_client
+      require_gcs!
+      @gcs_client ||= Google::Cloud::Storage.new(
+        project_id: cloud_config['project_id'],
+        credentials: cloud_config['gcs_credentials']
+      )
+    end
+
+    def gcs_bucket
+      @gcs_bucket ||= gcs_client.bucket(cloud_config['bucket'])
+    end
+
+    def azure_blob_client
+      require_azure!
+      @azure_blob_client ||= Azure::Storage::Blob::BlobService.create(
+        storage_account_name: azure_account_name,
+        storage_access_key: azure_access_key
+      )
+    end
+
+    def azure_container
+      cloud_config['container']
+    end
+
+    def s3_presigned_url(expires_in = 15.minutes)
+      return nil unless storage_backend == :s3 && cloud_config['bucket'].present?
+
+      require_s3!
+      signer = Aws::S3::Presigner.new(client: s3_client)
+      signer.presigned_url(
+        :get_object,
+        bucket: s3_bucket,
+        key: cloud_key,
+        expires_in: expires_in.to_i
+      )
+    rescue StandardError => e
+      Rails.logger.error(
+        "[CloudAttachment] Failed to generate S3 presigned URL for #{cloud_key} (attachment #{id}): #{e.message}"
+      )
+      nil
+    end
+
+    def gcs_presigned_url(expires_in = 15.minutes)
+      return nil unless storage_backend == :gcs && cloud_config['bucket'].present?
+
+      require_gcs!
+      file = gcs_bucket.file(cloud_key)
+      return nil unless file
+
+      file.signed_url(method: 'GET', expires: expires_in.to_i)
+    rescue StandardError => e
+      Rails.logger.error(
+        "[CloudAttachment] Failed to generate GCS presigned URL for #{cloud_key} (attachment #{id}): #{e.message}"
+      )
+      nil
+    end
+
+    def azure_presigned_url(expires_in = 15.minutes)
+      return nil unless storage_backend == :azure && cloud_config['container'].present?
+
+      require_azure!
+      start_time = Time.now.utc
+      expiry_time = start_time + expires_in.to_i
+
+      sas_token = azure_blob_client.generate_blob_sas_token(
+        azure_container,
+        cloud_key,
+        permission: 'r',
+        start_time: start_time.iso8601,
+        expiry_time: expiry_time.iso8601
+      )
+
+      "#{azure_blob_client.generate_uri("#{azure_container}/#{cloud_key}")}?#{sas_token}"
+    rescue StandardError => e
+      Rails.logger.error(
+        "[CloudAttachment] Failed to generate Azure presigned URL for #{cloud_key} (attachment #{id}): #{e.message}"
+      )
+      nil
+    end
+
+    def cleanup_temp_file
+      if @temp_file_obj && !@temp_file_obj.closed?
+        @temp_file_obj.close
+        begin
+          @temp_file_obj.unlink
+        rescue StandardError
+          nil
+        end
+      end
+      @temp_file_obj = nil
+      @cached_temp_diskfile = nil
+      if @upload_temp_to_unlink && File.exist?(@upload_temp_to_unlink)
+        begin
+          File.unlink(@upload_temp_to_unlink)
+        rescue StandardError
+          nil
+        end
+      end
+      @upload_temp_to_unlink = nil
+    end
+
+    def cleanup_after_thumbnail
+      cleanup_temp_file
+      Rails.logger.debug("[CloudAttachment] Cleaned up temp files after thumbnail for attachment #{id}")
     end
   end
 end
-
-# Ensure the patch is applied only once
-Attachment.include RedmineCloudAttachment::AttachmentPatch unless Attachment.included_modules.include?(RedmineCloudAttachment::AttachmentPatch)

--- a/lib/redmine_cloud_attachment/patches/attachments_controller_patch.rb
+++ b/lib/redmine_cloud_attachment/patches/attachments_controller_patch.rb
@@ -1,148 +1,111 @@
-# Rails.logger.info "[CloudAttachment LOAD] Attempting to load AttachmentsControllerPatch file: #{__FILE__}"
+# frozen_string_literal: true
+
 module RedmineCloudAttachment
   module Patches
     module AttachmentsControllerPatch
-      extend ActiveSupport::Concern
+      def download
+        if @attachment&.respond_to?(:cloud_diskfile?) && @attachment.cloud_diskfile?
+          expires_in = @attachment.cloud_expiry_time
+          presigned_url_value = @attachment.direct_download_url(expires_in)
 
-      included do
-        # Store the original methods
-        alias_method :original_download_for_cloud_pro, :download
-        alias_method :original_show_for_cloud_pro, :show
+          if presigned_url_value
+            begin
+              Rails.logger.info(
+                "[CloudAttachment] Redirecting to presigned URL for attachment ##{@attachment.id}"
+              )
 
-        # Override the download method
-        def download
-          # @attachment is typically set by a before_action like :find_attachment or :file_readable
-          # The presigned URL logic below should only apply if the user has rights to view/download the attachment.
-          # Basic check for @attachment and respond_to?(:direct_download_url) is done before calling direct_download_url.
-
-          if @attachment&.respond_to?(:direct_download_url) && @attachment.respond_to?(:cloud_diskfile?) && @attachment.cloud_diskfile?
-            # Get configurable expiry time (default 15 minutes)
-            expires_in = @attachment.cloud_expiry_time
-            presigned_url_value = @attachment.direct_download_url(expires_in)
-
-            if presigned_url_value
-              begin
-                Rails.logger.info "[CloudAttachment] Redirecting to presigned URL for attachment ##{@attachment.id} (#{@attachment.filename}) - offloading to cloud storage"
-                
-                # Update download counter for project/version attachments
-                if @attachment.container.is_a?(Version) || @attachment.container.is_a?(Project)
-                  @attachment.increment_download
-                end
-
-                redirect_to presigned_url_value, allow_other_host: true
-                return # Crucial to prevent original_download_for_cloud_pro from executing
-              rescue => e
-                Rails.logger.error "[CloudAttachment] Error during presigned URL redirect for attachment ##{@attachment&.id}: #{e.message}. Falling back to normal download."
-                # Fall through to original_download_for_cloud_pro
+              if @attachment.container.is_a?(Version) || @attachment.container.is_a?(Project)
+                @attachment.increment_download
               end
-            else
-              Rails.logger.warn "[CloudAttachment] Failed to generate presigned URL for attachment ##{@attachment.id}, falling back to normal download"
-            end
-          end
 
-          # If no presigned URL, or an error occurred, or attachment doesn't support it,
-          # or if the @attachment conditions were not met, call original download method.
-          Rails.logger.debug "[CloudAttachment] Using original download method for attachment ##{@attachment&.id}"
-          original_download_for_cloud_pro
-        end
-
-        # Override show method to optimize cloud file display
-        def show
-          # For cloud files that need content reading (text files, diffs), we still need to download
-          # But we can optimize by only doing this when necessary
-          if @attachment&.respond_to?(:cloud_diskfile?) && @attachment.cloud_diskfile?
-            Rails.logger.debug "[CloudAttachment] Processing show request for cloud attachment ##{@attachment.id} (#{@attachment.filename})"
-            
-            respond_to do |format|
-              format.html do
-                if @attachment.container.respond_to?(:attachments)
-                  @attachments = @attachment.container.attachments.to_a
-                  if index = @attachments.index(@attachment)
-                    @paginator = Redmine::Pagination::Paginator.new(
-                      @attachments.size, 1, index+1
-                    )
-                  end
-                end
-                
-                # For diff and text files, we need to download content
-                if @attachment.is_diff?
-                  Rails.logger.info "[CloudAttachment] Downloading diff content from cloud for attachment ##{@attachment.id}"
-                  @diff = File.read(@attachment.diskfile, :mode => "rb")
-                  @diff_type = params[:type] || User.current.pref[:diff_type] || 'inline'
-                  @diff_type = 'inline' unless %w(inline sbs).include?(@diff_type)
-                  # Save diff type as user preference
-                  if User.current.logged? && @diff_type != User.current.pref[:diff_type]
-                    User.current.pref[:diff_type] = @diff_type
-                    User.current.preference.save
-                  end
-                  render :action => 'diff'
-                elsif @attachment.is_text? && @attachment.filesize <= Setting.file_max_size_displayed.to_i.kilobyte
-                  Rails.logger.info "[CloudAttachment] Downloading text content from cloud for attachment ##{@attachment.id}"
-                  @content = File.read(@attachment.diskfile, :mode => "rb")
-                  render :action => 'file'
-                elsif @attachment.is_image?
-                  # For images, we can directly show the cloud URL if available
-                  expires_in = @attachment.cloud_expiry_time
-                  @direct_url = @attachment.direct_download_url(expires_in)
-                  Rails.logger.debug "[CloudAttachment] Using direct cloud URL for image display: #{@direct_url.present?}"
-                  render :action => 'image'
-                else
-                  render :action => 'other'
-                end
-              end
-              format.api
-            end
-            return
-          end
-
-          # Fall back to original show method for local files
-          original_show_for_cloud_pro
-        end
-
-        # Override find_downloadable_attachments to avoid calling readable? which triggers diskfile()
-        def find_downloadable_attachments
-          if defined?(@container) && @container
-            # For cloud attachments, skip the expensive readable? check
-            # We'll trust that cloud-stored files are readable via cloud storage
-            @attachments = @container.attachments.select do |attachment|
-              if attachment.respond_to?(:cloud_diskfile?) && attachment.cloud_diskfile?
-                attachment.disk_filename.present? # Simple check without file system access
-              else
-                attachment.readable? # Normal check for local files
-              end
-            end
-            
-            bulk_download_max_size = Setting.bulk_download_max_size.to_i.kilobytes
-            if @attachments.sum(&:filesize) > bulk_download_max_size
-              flash[:error] = l(:error_bulk_download_size_too_big,
-                                :max_size => number_to_human_size(bulk_download_max_size.to_i))
-              redirect_back_or_default(container_url, referer: true)
+              redirect_to(presigned_url_value, allow_other_host: true)
               return
-            end
-          end
-        end
-
-        # Override file_readable to avoid diskfile() check for cloud attachments  
-        def file_readable
-          if @attachment.respond_to?(:cloud_diskfile?) && @attachment.cloud_diskfile?
-            # For cloud files, use optimized readable? check that doesn't call diskfile()
-            if @attachment.readable?
-              true
-            else
-              Rails.logger.error "[CloudAttachment] Cloud attachment #{@attachment.id} is not accessible"
-              render_404
+            rescue StandardError => e
+              Rails.logger.error(
+                "[CloudAttachment] Presigned redirect failed for ##{@attachment&.id}: #{e.message}. Falling back."
+              )
             end
           else
-            # Use original logic for local files
-            if @attachment.readable?
-              true
+            Rails.logger.warn(
+              "[CloudAttachment] No presigned URL for attachment ##{@attachment.id}, falling back"
+            )
+          end
+        end
+
+        super
+      end
+
+      def show
+        unless @attachment&.respond_to?(:cloud_diskfile?) && @attachment.cloud_diskfile?
+          return super
+        end
+
+        respond_to do |format|
+          format.html do
+            if @attachment.container.respond_to?(:attachments)
+              @attachments = @attachment.container.attachments.to_a
+              if (index = @attachments.index(@attachment))
+                @paginator = Redmine::Pagination::Paginator.new(@attachments.size, 1, index + 1)
+              end
+            end
+
+            if @attachment.is_diff?
+              @diff = File.read(@attachment.diskfile, mode: 'rb')
+              @diff_type = params[:type] || User.current.pref[:diff_type] || 'inline'
+              @diff_type = 'inline' unless %w[inline sbs].include?(@diff_type)
+              if User.current.logged? && @diff_type != User.current.pref[:diff_type]
+                User.current.pref[:diff_type] = @diff_type
+                User.current.preference.save
+              end
+              render action: 'diff'
+            elsif @attachment.is_text? && @attachment.filesize <= Setting.file_max_size_displayed.to_i.kilobyte
+              @content = File.read(@attachment.diskfile, mode: 'rb')
+              render action: 'file'
+            elsif @attachment.is_image?
+              @direct_url = @attachment.direct_download_url(@attachment.cloud_expiry_time)
+              render action: 'image'
             else
-              logger.error "Cannot send attachment, #{@attachment.diskfile} does not exist or is unreadable."
-              render_404
+              render action: 'other'
             end
           end
+          format.api
+        end
+      end
+
+      def find_downloadable_attachments
+        return unless defined?(@container) && @container
+
+        @attachments = @container.attachments.select do |attachment|
+          if attachment.respond_to?(:cloud_diskfile?) && attachment.cloud_diskfile?
+            attachment.disk_filename.present?
+          else
+            attachment.readable?
+          end
+        end
+
+        bulk_download_max_size = Setting.bulk_download_max_size.to_i.kilobytes
+        return unless @attachments.sum(&:filesize) > bulk_download_max_size
+
+        flash[:error] = l(
+          :error_bulk_download_size_too_big,
+          max_size: number_to_human_size(bulk_download_max_size.to_i)
+        )
+        redirect_back_or_default(container_url, referer: true)
+      end
+
+      def file_readable
+        if @attachment.respond_to?(:cloud_diskfile?) && @attachment.cloud_diskfile?
+          return true if @attachment.readable?
+
+          Rails.logger.error("[CloudAttachment] Cloud attachment #{@attachment.id} is not accessible")
+          render_404
+        elsif @attachment.readable?
+          true
+        else
+          logger.error "Cannot send attachment, #{@attachment.diskfile} does not exist or is unreadable."
+          render_404
         end
       end
     end
   end
-end 
+end

--- a/lib/redmine_cloud_attachment/patches/attachments_helper_patch.rb
+++ b/lib/redmine_cloud_attachment/patches/attachments_helper_patch.rb
@@ -1,29 +1,18 @@
+# frozen_string_literal: true
+
 module RedmineCloudAttachment
   module Patches
     module AttachmentsHelperPatch
-      extend ActiveSupport::Concern
+      def render_api_attachment_attributes(attachment, api)
+        super
 
-      included do
-        # Override render_api_attachment_attributes to use direct cloud URLs when available
-        alias_method :original_render_api_attachment_attributes, :render_api_attachment_attributes
+        return unless attachment.respond_to?(:cloud_diskfile?) && attachment.cloud_diskfile?
 
-        def render_api_attachment_attributes(attachment, api)
-          original_render_api_attachment_attributes(attachment, api)
-          
-          # Add direct download URL for cloud attachments if available
-          if attachment.respond_to?(:direct_download_url) && attachment.respond_to?(:cloud_diskfile?) && attachment.cloud_diskfile?
-            expires_in = attachment.cloud_expiry_time
-            direct_url = attachment.direct_download_url(expires_in)
-            if direct_url
-              api.direct_content_url direct_url
-              Rails.logger.debug "[CloudAttachment] Added direct cloud URL to API response for attachment #{attachment.id}"
-            end
-          end
-        end
+        direct_url = attachment.direct_download_url(attachment.cloud_expiry_time)
+        return unless direct_url
 
-        # Note: We no longer override thumbnail_path as we now generate real thumbnails for cloud attachments
-        # The thumbnail method in attachment_patch.rb handles cloud file thumbnails properly
+        api.direct_content_url direct_url
       end
     end
   end
-end 
+end

--- a/lib/redmine_cloud_attachment/version.rb
+++ b/lib/redmine_cloud_attachment/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RedmineCloudAttachment
-  VERSION = '1.2.1'
+  VERSION = '1.2.2'
 end

--- a/lib/redmine_cloud_attachment/version.rb
+++ b/lib/redmine_cloud_attachment/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RedmineCloudAttachment
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end

--- a/lib/tasks/attachments.rake
+++ b/lib/tasks/attachments.rake
@@ -1,37 +1,46 @@
+# frozen_string_literal: true
+
 namespace :attachments do
-  desc 'Prefix disk_filename with cloud storage identifier (s3_, gcs_, azure_) if missing'
+  desc <<~DESC.gsub(/\s+/, ' ').strip
+    DANGEROUS: Prefix disk_filename with cloud storage identifier (s3_/gcs_/azure_)
+    for rows that are not already prefixed. Only run after migrating existing
+    local files into the configured cloud backend. Requires CONFIRM=1.
+  DESC
   task prefix_cloud_filenames: :environment do
+    unless ENV['CONFIRM'] == '1'
+      abort <<~MSG
+        Refusing to run. This task rewrites Attachment#disk_filename and can mark
+        local-only files as cloud-backed incorrectly.
+
+        After you have copied files to the cloud backend, re-run with:
+          CONFIRM=1 bundle exec rake attachments:prefix_cloud_filenames RAILS_ENV=production
+      MSG
+    end
+
     storage = Redmine::Configuration['storage'].to_s
     prefix = case storage
              when 's3', 'gcs', 'azure'
                "#{storage}_"
-             else
-               nil
              end
 
     unless prefix
-      puts "❌ Unsupported or missing storage backend: #{storage.inspect}"
-      exit 1
+      abort "Unsupported or missing storage backend: #{storage.inspect}"
     end
 
-    puts "🔍 Updating attachments for storage: #{storage}..."
+    puts "Updating attachments for storage=#{storage}..."
 
     updated = 0
-
     Attachment.find_each do |attachment|
-      next unless attachment.disk_filename.present?
+      next if attachment.disk_filename.blank?
       next if attachment.disk_filename.start_with?(prefix)
-
-      # Avoid double-prefixing if already prefixed with another cloud type
       next if attachment.disk_filename.match?(/^(s3|gcs|azure)_/)
 
       new_filename = "#{prefix}#{attachment.disk_filename}"
-
       attachment.update_column(:disk_filename, new_filename)
-      puts "✅ Updated ##{attachment.id} to #{new_filename}"
+      puts "Updated ##{attachment.id} -> #{new_filename}"
       updated += 1
     end
 
-    puts "🎉 Done. Total attachments updated: #{updated}"
+    puts "Done. Total attachments updated: #{updated}"
   end
 end

--- a/test/unit/basic_functionality_test.rb
+++ b/test/unit/basic_functionality_test.rb
@@ -162,4 +162,28 @@ class BasicFunctionalityTest < ActiveSupport::TestCase
 
     assert_not text_attachment.thumbnailable?, 'Text attachment should not be thumbnailable'
   end
+
+  def test_s3_client_options_include_minio_endpoint
+    attachment = Attachment.new(disk_filename: 's3_test.txt')
+    attachment.define_singleton_method(:cloud_config) do
+      {
+        'bucket' => 'redmine-attachments',
+        'region' => 'us-east-1',
+        'access_key_id' => 'minioadmin',
+        'secret_access_key' => 'minioadmin',
+        'endpoint' => 'http://demo-minio:9000',
+        'public_endpoint' => 'http://localhost:9000',
+        'force_path_style' => true
+      }
+    end
+
+    opts = attachment.send(:s3_client_options)
+    assert_equal 'http://demo-minio:9000', opts[:endpoint]
+    assert_equal true, opts[:force_path_style]
+    assert_equal 'us-east-1', opts[:region]
+
+    public_opts = attachment.send(:s3_client_options, endpoint: 'http://localhost:9000')
+    assert_equal 'http://localhost:9000', public_opts[:endpoint]
+    assert_equal true, public_opts[:force_path_style]
+  end
 end

--- a/test/unit/basic_functionality_test.rb
+++ b/test/unit/basic_functionality_test.rb
@@ -103,21 +103,63 @@ class BasicFunctionalityTest < ActiveSupport::TestCase
     assert [true, false].include?(result), "readable? should return boolean"
   end
 
+  def test_local_readable_delegates_to_core_via_super
+    attachment = Attachment.new(
+      filename: 'local.jpg',
+      disk_filename: '260724_local.jpg',
+      content_type: 'image/jpeg'
+    )
+
+    assert_not attachment.cloud_diskfile?
+    assert attachment.method(:readable?).owner == RedmineCloudAttachment::AttachmentPatch
+    assert_not_nil attachment.method(:readable?).super_method,
+                   'prepend must keep Attachment#readable? reachable via super'
+    # Without a real file this is false, but must not raise NoMethodError
+    assert_equal false, attachment.readable?
+  end
+
+  def test_azure_credential_helpers_accept_sample_and_legacy_keys
+    attachment = Attachment.new(
+      filename: 'test.txt',
+      disk_filename: 'azure_test_123.txt'
+    )
+
+    attachment.define_singleton_method(:cloud_config) do
+      {
+        'container' => 'attachments',
+        'storage_account_name' => 'sampleacct',
+        'storage_access_key' => 'samplekey'
+      }
+    end
+    assert_equal 'sampleacct', attachment.send(:azure_account_name)
+    assert_equal 'samplekey', attachment.send(:azure_access_key)
+
+    attachment.define_singleton_method(:cloud_config) do
+      {
+        'container' => 'attachments',
+        'account_name' => 'legacyacct',
+        'access_key' => 'legacykey'
+      }
+    end
+    assert_equal 'legacyacct', attachment.send(:azure_account_name)
+    assert_equal 'legacykey', attachment.send(:azure_access_key)
+  end
+
   def test_thumbnailable_for_image_attachments
     image_attachment = Attachment.new(
       filename: 'test.jpg',
       disk_filename: 's3_test_123.jpg',
       content_type: 'image/jpeg'
     )
-    
-    assert image_attachment.thumbnailable?, "Image attachment should be thumbnailable"
-    
+
+    assert image_attachment.thumbnailable?, 'Image attachment should be thumbnailable'
+
     text_attachment = Attachment.new(
       filename: 'test.txt',
       disk_filename: 's3_test_123.txt',
       content_type: 'text/plain'
     )
-    
-    assert_not text_attachment.thumbnailable?, "Text attachment should not be thumbnailable"
+
+    assert_not text_attachment.thumbnailable?, 'Text attachment should not be thumbnailable'
   end
-end 
+end


### PR DESCRIPTION
## Summary

Addresses technical-review findings, fixes local thumbnail 500 (`super` broken after `include`+`class_eval`), and adds **MinIO / S3-compatible** support via `endpoint`, `force_path_style`, and `public_endpoint` (v1.2.2).

## Type
- [x] Bug fix
- [x] Feature
- [x] Refactor

## Changes

- Prepend `AttachmentPatch` so local `readable?` / `thumbnail` / `diskfile` call Redmine core via `super`
- Azure dual credential keys; lazy SDK require; streaming SHA256 upload
- `after_initialize` boot for Zeitwerk; rake `CONFIRM=1` guard
- **MinIO**: `s3.endpoint`, `force_path_style`, `public_endpoint` for browser-reachable presigned URLs
- README / sample YAML / CHANGELOG → **1.2.2**

## Testing

- [x] Unit tests updated (Azure keys, `super` readable?, MinIO client options)
- [x] Manual: local thumbnail `/attachments/thumbnail/:id/200` → 200
- [x] Manual: demo MinIO upload + presigned download via `localhost:9000`

## Checklist
- [x] CHANGELOG.md updated
- [x] Docs/README updated
- [x] No new gem without approval